### PR TITLE
Event details modal, ability to update your status for an event, and filter events.

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-import { useUser } from "./contexts/UserContext";
 import WithAuth from './components/WithAuth';
 import WelcomePage from "./pages/WelcomePage";
 import SignUpPage from "./pages/SignUpPage";

--- a/client/src/components/Event.jsx
+++ b/client/src/components/Event.jsx
@@ -9,13 +9,13 @@ import "../styles/Card.css";
 
 const Event = ( {eventData, refetchData}) => {
 
-    const [statusState, setStatusState] = useState(eventData.status); //change to event object? 
+    // const [statusState, setStatusState] = useState(eventData.status); //change to event object? 
     const [isEventDetailsModalVisible, setIsEventDetailsModalVisible] = useState(false);
 
     const { title, description, zip_code, address  } = eventData.event; //due to nature of prisma relational queries, event table data is in nested event property
 
     const renderStatus = () => {
-        switch(statusState) {
+        switch(eventData.status) {
             case Status.ACCEPTED: 
                 return <AcceptedIcon className="status-icon"/>
             case Status.PENDING: 
@@ -31,13 +31,6 @@ const Event = ( {eventData, refetchData}) => {
     const closeModal = () => {
         setIsEventDetailsModalVisible(false);
     }
-
-    const updateStatus = (newStatus) => {
-        setStatusState(newStatus);
-        refetchData(); //Note: need to refetch data in Main Page so that filtering will work with updated events
-                        //This doesn't feel like the best solution - would this be a case for useContext? Or is there a better option?
-    }
-    
     
     return (
         <>
@@ -49,7 +42,7 @@ const Event = ( {eventData, refetchData}) => {
             <p>{description}</p>
             <p>{zip_code}</p>
         </div>
-        {isEventDetailsModalVisible && <EventDetailsModal closeModal={closeModal} eventData={eventData} currStatus={statusState} updateStatus={updateStatus}/>}
+        {isEventDetailsModalVisible && <EventDetailsModal onModalClose={closeModal} eventData={eventData.event} initialStatus={eventData.status} onStatusChange={() => {refetchData()}}/>}
         </>
     )
 }

--- a/client/src/components/Event.jsx
+++ b/client/src/components/Event.jsx
@@ -1,24 +1,54 @@
+import { useState } from 'react';
+import { LiaUserTimesSolid as RejectedIcon} from "react-icons/lia";//icon for "rejected event"
+import { LiaUserCheckSolid as AcceptedIcon} from "react-icons/lia";//icon for "accepted event"
+import { LiaUserClockSolid as PendingIcon} from "react-icons/lia";//icon for "pending response"
+import EventDetailsModal from './EventDetailsModal';
+import { Status } from "../utils/utils";
 import "../styles/Card.css";
-import { LiaUserTimesSolid } from "react-icons/lia";//icon for "rejected event"
-import { LiaUserCheckSolid } from "react-icons/lia";//icon for "accepted event"
-import { LiaUserClockSolid } from "react-icons/lia";//icon for "pending response"
 
 
-const Event = ( {event_id, status, eventData}) => {
+const Event = ( {eventData}) => {
+
+    const [statusState, setStatusState] = useState(eventData.status); //change to event object? 
+    const [isEventDetailsModalVisible, setIsEventDetailsModalVisible] = useState(false);
+
+    const { title, description, zip_code, address  } = eventData.event; //due to nature of prisma relational queries, event table data is in nested event property
+
+    const renderStatus = () => {
+        switch(statusState) {
+            case Status.ACCEPTED: 
+                return <AcceptedIcon className="status-icon"/>
+            case Status.PENDING: 
+                return <PendingIcon className="status-icon"/>
+            case Status.REJECTED:
+                return <RejectedIcon className="status-icon"/>
+        }
+    }
+
+    const openModal = () => {
+        setIsEventDetailsModalVisible(true)
+    }
+    const closeModal = () => {
+        setIsEventDetailsModalVisible(false);
+    }
+
+    const updateStatus = (newStatus) => {
+        setStatusState(newStatus);
+    }
     
-    const { title, description, zip_code, address  } = eventData.event; //due to nature of prisma relational queries, event table data is in nested event propert
+    
     return (
-        <div className="card" onClick={() => {
-        }}>
+        <>
+        <div className="card" onClick={openModal}>
             <section className="card-header">
-                {/* the below icon will be chnaged based on event status */}
-                <LiaUserClockSolid className="status-icon"/>
+                {renderStatus()}
                 <h4 className="title">{title}</h4>
             </section>
-            {/* <img src="https://picsum.photos/200/200" /> */}
             <p>{description}</p>
             <p>{zip_code}</p>
         </div>
+        {isEventDetailsModalVisible && <EventDetailsModal closeModal={closeModal} eventData={eventData} currStatus={statusState} updateStatus={updateStatus}/>}
+        </>
     )
 }
 

--- a/client/src/components/Event.jsx
+++ b/client/src/components/Event.jsx
@@ -7,7 +7,7 @@ import { Status } from "../utils/utils";
 import "../styles/Card.css";
 
 
-const Event = ( {eventData}) => {
+const Event = ( {eventData, refetchData}) => {
 
     const [statusState, setStatusState] = useState(eventData.status); //change to event object? 
     const [isEventDetailsModalVisible, setIsEventDetailsModalVisible] = useState(false);
@@ -34,6 +34,8 @@ const Event = ( {eventData}) => {
 
     const updateStatus = (newStatus) => {
         setStatusState(newStatus);
+        refetchData(); //Note: need to refetch data in Main Page so that filtering will work with updated events
+                        //This doesn't feel like the best solution - would this be a case for useContext? Or is there a better option?
     }
     
     

--- a/client/src/components/EventDetailsModal.jsx
+++ b/client/src/components/EventDetailsModal.jsx
@@ -1,22 +1,21 @@
+import { useState } from 'react';
 import { Status } from "../utils/utils";
 import { useUser } from "../contexts/UserContext";
 import "../styles/Modal.css";
 
-const EventDetailsModal = ( {closeModal, eventData, currStatus, updateStatus}) => {
+const EventDetailsModal = ( {onModalClose, eventData, initialStatus, onStatusChange}) => {
 
-    const { user } = useUser();
+    const [statusState, setStatusState] = useState(initialStatus); //change to event object? 
 
-    const { event_id } = eventData;
-    const { address, description, title, zip_code } = eventData.event; //needs to be done this way due to nature of database query many-to-many
+    const { id, address, description, title, zip_code } = eventData; //needs to be done this way due to nature of database query many-to-many
 
     const handleStatusUpdate = async (event) => {
         //put request to change status of event
         try {
-            const response = await fetch(`http://localhost:3000/user/events/${event_id}`, {
+            const response = await fetch(`http://localhost:3000/user/events/${id}`, { //path param is event id
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                    "user_id": user.id,
                     "updatedStatus": event.target.value
                 }),
                 credentials: "include",
@@ -25,7 +24,8 @@ const EventDetailsModal = ( {closeModal, eventData, currStatus, updateStatus}) =
             const data = await response.json();
 
             if (response.ok) {
-                updateStatus(event.target.value);
+                setStatusState(event.target.value);
+                onStatusChange(event.target.value);
             } else {
                 console.error(data.error);
             }
@@ -39,13 +39,13 @@ const EventDetailsModal = ( {closeModal, eventData, currStatus, updateStatus}) =
         <div className="modal-overlay"> 
             <div className="modal-popup">       
                 <div className="modal-content">
-                    <button className="close-btn" onClick={closeModal}>X</button>
+                    <button className="close-btn" onClick={onModalClose}>X</button>
                     <h4>{title}</h4>
                     <p>{description}</p>
                     <p>{address}</p>
                     <p>{zip_code}</p>
                     <div className="select-form">
-                        <select name="update-sattus" defaultValue={currStatus} onChange={handleStatusUpdate}>
+                        <select name="update-sattus" defaultValue={statusState} onChange={handleStatusUpdate}>
                             <option disabled value="">Choose status</option>
                             <option value={Status.PENDING}>{Status.PENDING}</option>
                             <option value={Status.ACCEPTED}>{Status.ACCEPTED}</option>

--- a/client/src/components/EventDetailsModal.jsx
+++ b/client/src/components/EventDetailsModal.jsx
@@ -1,0 +1,63 @@
+import { Status } from "../utils/utils";
+import { useUser } from "../contexts/UserContext";
+import "../styles/Modal.css";
+
+const EventDetailsModal = ( {closeModal, eventData, currStatus, updateStatus}) => {
+
+    const { user } = useUser();
+
+    const { event_id } = eventData;
+    const { address, description, title, zip_code } = eventData.event; //needs to be done this way due to nature of database query many-to-many
+
+    const handleStatusUpdate = async (event) => {
+        //put request to change status of event
+        try {
+            const response = await fetch(`http://localhost:3000/user/events/${event_id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    "user_id": user.id,
+                    "updatedStatus": event.target.value
+                }),
+                credentials: "include",
+            });
+
+            const data = await response.json();
+
+            if (response.ok) {
+                updateStatus(event.target.value);
+            } else {
+                console.error(data.error);
+            }
+        } catch (error) {
+            console.error("Network error:", error);
+        }
+
+    }
+
+    return (
+        <div className="modal-overlay"> 
+            <div className="modal-popup">       
+                <div className="modal-content">
+                    <button className="close-btn" onClick={closeModal}>X</button>
+                    <h4>{title}</h4>
+                    <p>{description}</p>
+                    <p>{address}</p>
+                    <p>{zip_code}</p>
+                    <div className="select-form">
+                        <select name="update-sattus" defaultValue={currStatus} onChange={handleStatusUpdate}>
+                            <option disabled value="">Choose status</option>
+                            <option value={Status.PENDING}>{Status.PENDING}</option>
+                            <option value={Status.ACCEPTED}>{Status.ACCEPTED}</option>
+                            <option value={Status.REJECTED}>{Status.REJECTED}</option>
+                        </select>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    )
+
+}
+
+export default EventDetailsModal;

--- a/client/src/components/FilterOptions.jsx
+++ b/client/src/components/FilterOptions.jsx
@@ -1,9 +1,9 @@
 import { Status } from "../utils/utils";
 
-const FilterOptions = ( {filterEvents}) => {
+const FilterOptions = ( {onFilterChange}) => {
 
     const handleFilterClick = (event) => {
-        filterEvents(event.target.value)
+        onFilterChange(event.target.value)
     }
 
     return <div className="filter-form">

--- a/client/src/components/FilterOptions.jsx
+++ b/client/src/components/FilterOptions.jsx
@@ -7,9 +7,11 @@ const FilterOptions = ( {filterEvents}) => {
     }
 
     return <div className="filter-form">
-        <button value={Status.PENDING} onClick={handleFilterClick}>{Status.PENDING}</button>
-        <button value={Status.ACCEPTED} onClick={handleFilterClick}>{Status.ACCEPTED}</button>
-        <button value={Status.REJECTED} onClick={handleFilterClick}>{Status.REJECTED}</button>
+        {
+            Object.values(Status).map((status, index) => (
+                <button key={index} value={status} onClick={handleFilterClick}>{status}</button>
+            ))
+        }
     </div>
 }
 

--- a/client/src/components/FilterOptions.jsx
+++ b/client/src/components/FilterOptions.jsx
@@ -1,0 +1,16 @@
+import { Status } from "../utils/utils";
+
+const FilterOptions = ( {filterEvents}) => {
+
+    const handleFilterClick = (event) => {
+        filterEvents(event.target.value)
+    }
+
+    return <div className="filter-form">
+        <button value={Status.PENDING} onClick={handleFilterClick}>{Status.PENDING}</button>
+        <button value={Status.ACCEPTED} onClick={handleFilterClick}>{Status.ACCEPTED}</button>
+        <button value={Status.REJECTED} onClick={handleFilterClick}>{Status.REJECTED}</button>
+    </div>
+}
+
+export default FilterOptions;

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -6,7 +6,7 @@ import "../styles/NavBar.css";
 
 const NavBar = () => {
 
-    const { user, setUser } = useUser(); 
+    const { setUser } = useUser(); 
 
     const navigate = useNavigate();
 

--- a/client/src/components/SideBar.jsx
+++ b/client/src/components/SideBar.jsx
@@ -4,11 +4,13 @@ import "../styles/SideBar.css"
 const SideBar = ({ handleTabSelect }) => {
 
     return <nav className="sidebar"> 
-        {Object.values(Tab).map(currentTab => (
-          <div className="side-tab" onClick={() => {handleTabSelect(currentTab)}}>
-              <h3 className="title-text">{currentTab}</h3>
-          </div>
-        ))}
+        {
+            Object.values(Tab).map((currentTab, index) => (
+                <div key={index} className="side-tab" onClick={() => {handleTabSelect(currentTab)}}>
+                    <h3 className="title-text">{currentTab}</h3>
+                </div>
+            ))
+        }
     </nav>
 }
 

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -1,21 +1,17 @@
-// import { useUser } from "../contexts/UserContext";
 import Event from "../components/Event";
+import FilterOptions from "../components/FilterOptions";
 import "../styles/CardListContainer.css"
 
-const EventsList = ({ eventsArr }) => {
-
-    // const { user } = useUser();
+const EventsList = ({ eventsArr, filterEvents }) => {
 
     return (
         <>
-        {/* <h2>{user}</h2> */}
         <h2>Events</h2>
+        <FilterOptions filterEvents={filterEvents}/>
         <div className="card-container">
             {eventsArr?.map((event) => {
                 return <Event 
                     key={event.event_id}
-                    event_id={event.event_id}
-                    status={event.status}
                     eventData={event}
                 />
             })}

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -3,12 +3,12 @@ import Event from "../components/Event";
 import FilterOptions from "../components/FilterOptions";
 import "../styles/CardListContainer.css"
 
-const EventsList = ({ eventsArr, filterEvents, refetchData }) => {
+const EventsList = ({ eventsArr, onFilterChange, refetchData }) => {
 
     return (
         <>
         <h2>Events</h2>
-        <FilterOptions filterEvents={filterEvents}/>
+        <FilterOptions onFilterChange={onFilterChange}/>
         <div className="card-container">
             <Suspense fallback={<p>Loading...</p>}>
                 {eventsArr.map((event) => {

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import Event from "../components/Event";
 import FilterOptions from "../components/FilterOptions";
 import "../styles/CardListContainer.css"
@@ -9,12 +10,14 @@ const EventsList = ({ eventsArr, filterEvents }) => {
         <h2>Events</h2>
         <FilterOptions filterEvents={filterEvents}/>
         <div className="card-container">
-            {eventsArr?.map((event) => {
-                return <Event 
-                    key={event.event_id}
-                    eventData={event}
-                />
-            })}
+            <Suspense fallback={<p>Loading...</p>}>
+                {eventsArr.map((event) => {
+                    return <Event 
+                        key={event.event_id}
+                        eventData={event}
+                    />
+                })}
+            </Suspense>
         </div>
         </>
     )

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -3,7 +3,7 @@ import Event from "../components/Event";
 import FilterOptions from "../components/FilterOptions";
 import "../styles/CardListContainer.css"
 
-const EventsList = ({ eventsArr, filterEvents }) => {
+const EventsList = ({ eventsArr, filterEvents, refetchData }) => {
 
     return (
         <>
@@ -15,6 +15,7 @@ const EventsList = ({ eventsArr, filterEvents }) => {
                     return <Event 
                         key={event.event_id}
                         eventData={event}
+                        refetchData={refetchData}
                     />
                 })}
             </Suspense>

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -1,4 +1,3 @@
-
 import "../styles/CardListContainer.css"
 
 const GroupsList = () => {

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -54,7 +54,7 @@ const MainPage = () => {
             {/* Populate events or groups depending what tab was clicked on the side */}
             {/* As you add more tabs, change to switch statement! */}
             {selectedTab == Tab.EVENTS? 
-                <EventsList eventsArr={events} filterEvents={filterEvents}/> : <GroupsList />
+                <EventsList eventsArr={events} filterEvents={filterEvents} refetchData={() => {fetchEvents()}}/> : <GroupsList />
             }
             
         </div>

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -54,7 +54,7 @@ const MainPage = () => {
             {/* Populate events or groups depending what tab was clicked on the side */}
             {/* As you add more tabs, change to switch statement! */}
             {selectedTab == Tab.EVENTS? 
-                <EventsList eventsArr={events} filterEvents={filterEvents} refetchData={() => {fetchEvents()}}/> : <GroupsList />
+                <EventsList eventsArr={events} onFilterChange={filterEvents} refetchData={() => {fetchEvents()}}/> : <GroupsList />
             }
             
         </div>

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import EventsList from './EventsList';
@@ -7,6 +7,8 @@ import { Tab } from "../utils/utils";
 import "../styles/MainPage.css";
 
 const MainPage = () => {
+
+    const defaultEvents = useRef([]);
 
     const [selectedTab, setSelectedTab] = useState(Tab.EVENTS);
     const [events, setEvents] = useState([]);
@@ -26,13 +28,21 @@ const MainPage = () => {
             const data = await response.json();
 
             if (response.ok) {
-                setEvents(data[0].events);
+                setEvents(data.events);
+                defaultEvents.current = data.events;
             } else {
                 console.error(data.error);
             }
         } catch (error) {
             console.error("Network error:", error);
         }
+    }
+
+    const filterEvents = (filter) => {
+        const newEvents = defaultEvents.current.filter(event => 
+            event.status === filter
+        );
+        setEvents(newEvents);
     }
 
     return (
@@ -44,7 +54,7 @@ const MainPage = () => {
             {/* Populate events or groups depending what tab was clicked on the side */}
             {/* As you add more tabs, change to switch statement! */}
             {selectedTab == Tab.EVENTS? 
-                <EventsList eventsArr={events}/> : <GroupsList />
+                <EventsList eventsArr={events} filterEvents={filterEvents}/> : <GroupsList />
             }
             
         </div>

--- a/client/src/styles/Card.css
+++ b/client/src/styles/Card.css
@@ -1,9 +1,8 @@
 .card {
-    /* border: solid rgb(133, 131, 131) 5px; */
     box-shadow: 0px 10px 10px rgb(114, 112, 112);  
     max-height: 400px;
 }
-/*Reordered*/
+
 .card-header {
     display: flex;
     flex-direction: column;

--- a/client/src/styles/Modal.css
+++ b/client/src/styles/Modal.css
@@ -1,0 +1,49 @@
+.modal-overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width:100vw;
+    height:100vh;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 2;
+    
+}
+
+.modal-popup {
+    display: block;
+    z-index: 2;
+    min-width: 60%;
+    max-height: 80%;
+    margin-bottom: 20px;
+    margin-top: 50px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    scrollbar-width: none;
+    /*Below is to center the modal relative to the browser window*/
+    position: fixed;
+    left: 50%;
+    top: 40%;
+    transform: translate(-40%, -50%);    
+}
+
+.modal-popup * {
+    opacity: 1;
+    padding: 6px;
+}
+
+.modal-content {
+    background-color: white;
+    max-width: 70%;
+    border-style: outset;
+    border-width: 7px;
+    overflow: scroll;
+    box-shadow: 10px 10px 10px rgb(114, 112, 112);
+}
+
+.modal-content .close-btn {
+    position: fixed;
+    left: 67%;
+    top: 5%;    
+    z-index: 3; 
+}

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -4,4 +4,11 @@ const Tab = Object.freeze({
     GROUPS: "Groups"
 });
 
-export { Tab };
+//enums for user's status for an event or group
+const Status = Object.freeze({
+    PENDING: "PENDING",
+    ACCEPTED: "ACCEPTED",
+    REJECTED: "REJECTED"
+});
+
+export { Tab, Status };

--- a/server/prisma/migrations/20250626194625_adjusted_enum_naming/migration.sql
+++ b/server/prisma/migrations/20250626194625_adjusted_enum_naming/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - The values [PENDING,ACCEPTED,REJECTED] on the enum `Status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "Status_new" AS ENUM ('Pending', 'Accepted', 'Rejected');
+ALTER TABLE "Event_User" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Event_User" ALTER COLUMN "status" TYPE "Status_new" USING ("status"::text::"Status_new");
+ALTER TYPE "Status" RENAME TO "Status_old";
+ALTER TYPE "Status_new" RENAME TO "Status";
+DROP TYPE "Status_old";
+ALTER TABLE "Event_User" ALTER COLUMN "status" SET DEFAULT 'Pending';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Event_User" ALTER COLUMN "status" SET DEFAULT 'Pending';

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -90,14 +90,14 @@ router.post('/login', loginLimiter, async (req, res) => {
         })
 
         if (!user) {
-            return res.status(401).json({ error: "Invalid email or password" })
+            return res.status(401).json({ error: "Invalid email" })
         }
 
         //if user was found, compare entered password to hashed password in database
 
         bcrypt.compare(password, user.password, (err, result) => {
             if (err) {
-                return res.status(500).json({ error: "Error validating email or password, come back later." })
+                return res.status(500).json({ error: "Error validating password, come back later." })
             }
             if (result) {
                 //Successful login:

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -36,26 +36,26 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
 //update user's status for an event
 router.patch('/user/events/:event_id', async (req, res) => {
     const event_id = parseInt(req.params.event_id);
-    const {user_id, updatedStatus} = req.body; //wasn't sure if user_id should be a path parameter because it may be sensitive information
+    const {updatedStatus} = req.body; //wasn't sure if user_id should be a path parameter because it may be sensitive information
 
     try {
-        const event = await prisma.event_User.findUnique({
+        const event_user = await prisma.event_User.findUnique({
             where: {
                 user_id_event_id: {
-                    user_id: user_id,
+                    user_id: req.session.userId,
                     event_id: event_id
                 }
             }
         });
 
-        if (!event) {
+        if (!event_user) {
             res.status(404).send('This user - event relationship does not exist');
         }
 
         const updatedEvent = await prisma.event_User.update({
             where: {
                 user_id_event_id: {
-                    user_id: user_id,
+                    user_id: req.session.userId,
                     event_id: event_id
                 }
             },


### PR DESCRIPTION
## Description

With this pull request you can now click on an event and see a modal with event details (more details with better labelling will be done later). Within the modal there is a dropdown for the user to update their status on the event and see the changes on the main page. User can also filter the events displayed based on status.

I also implemented feedback from previous pull requests, but still have to implemented the following feedback:
-fix variable names ( I have some mixed camel case and snake case)
-fix my switch statement in Event.jsx
-fixing nullable address field in database

In the next PR I will aim to fix these and accomplish the following...
-Add an "all" filter option
-Have the button that was clicked on be shaded to make what was clicked obvious to the user
-Start on interests page under profile and start working towards how interests will be set up for my first technical challenge

## Milestones
Completed:
https://github.com/MetaU-Project-Erin-Turgut/Capstone_Project_Erin_Turgut/issues/4
https://github.com/MetaU-Project-Erin-Turgut/Capstone_Project_Erin_Turgut/issues/3

## Resources
https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations

## Test Plan
<img width="1385" alt="Screenshot 2025-06-26 at 4 27 36 PM" src="https://github.com/user-attachments/assets/f937ce17-bffa-47a1-9570-0ec26e28453c" />

<img width="1381" alt="Screenshot 2025-06-26 at 4 27 57 PM" src="https://github.com/user-attachments/assets/eb95e80d-a133-4414-a346-5949ceddf56f" />

