### PR TITLE
Interests tree data loaded onto Interests page and can be navigated through

### DIFF
--- a/client/src/components/InterestLevelColumn.jsx
+++ b/client/src/components/InterestLevelColumn.jsx
@@ -1,10 +1,16 @@
+import { Suspense } from 'react';
 import InterestTile from './InterestTile';
 import '../styles/InterestLevelColumn.css';
 
-const InterestLevelColumn = () => {
+//These are the vertical columns that hold all interests at a certain level
+const InterestLevelColumn = ({ interests, onInterestClick }) => {
     return <div className="interest-column">
-        <InterestTile />
-        <InterestTile />
+        <Suspense fallback={<p>Loading...</p>}>
+            {interests.map((interest) => (
+                <InterestTile key={interest.id} interest={interest} onTileClick={onInterestClick}/>
+            ))}
+        </Suspense>
+
     </div>
 }
 

--- a/client/src/components/InterestTile.jsx
+++ b/client/src/components/InterestTile.jsx
@@ -1,8 +1,11 @@
 import '../styles/InterestTile.css';
 
-const InterestTile = () => {
-    return <div className="interest-tile">
-        <p>Example interest</p>
+const InterestTile = ({ interest, onTileClick }) => {
+    return <div className="interest-tile" onClick={() => {
+        onTileClick();
+        //add class to change shading
+        }}>
+        <p>{interest.title}</p>
     </div>
 }
 

--- a/client/src/components/InterestTile.jsx
+++ b/client/src/components/InterestTile.jsx
@@ -1,12 +1,14 @@
 import '../styles/InterestTile.css';
 
 const InterestTile = ({ interest, onTileClick }) => {
-    return <div className="interest-tile" onClick={() => {
-        onTileClick();
-        //add class to change shading
-        }}>
-        <p>{interest.title}</p>
-    </div>
+    return ( 
+        <div className="interest-tile" onClick={() => {
+                onTileClick(interest.id, interest.level);
+                //add class to change shading
+            }}>
+            <p>{interest.title}</p>
+        </div>
+    )
 }
 
 export default InterestTile;

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -16,7 +16,7 @@ const InterestList = () => {
     const fetchRootInterests = async () => {
             try {
                 const apiResultData = await APIUtils.fetchRootInterests();
-                const newArr = [...interestsByLevel];
+                const newArr = []; 
                 newArr[0] = apiResultData;
                 setInterestsByLevel(newArr);
             } catch (error) {
@@ -25,14 +25,28 @@ const InterestList = () => {
             }
         }
 
-    const addNewColumn = () => {
-        //call setInterestsByLevel => increase by 1 new pair with fetched values
-
+    const addNewColumn = async (interestId, clickedInterestLevel) => {
+        try {
+            const apiResultData = await APIUtils.fetchImmediateChildren(interestId);
+            if (apiResultData.length !== 0) { //meaning no children i.e have reached leaf in the tree
+                const newArr = [];
+                for (let i = 0; i < clickedInterestLevel; i++) {
+                    newArr[i] = interestsByLevel[i];
+                }
+                newArr[clickedInterestLevel] = apiResultData;
+                setInterestsByLevel(newArr);
+            } else {
+                alert("No more subinterests!"); //will have better visual display for this later
+            }
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
     }
 
     return <div className="interest-list-container">
         <Suspense fallback={<p>Loading...</p>}>
-            {interestsByLevel.map((interestsArr, index) => (
+            {interestsByLevel.map((interestsArr) => (
                 <InterestLevelColumn 
                     key={interestsArr[0].id} //use first interest's id in level as level's key.
                     interests={interestsArr}

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -5,10 +5,9 @@ import "../styles/InterestList.css";
 
 const InterestList = () => {
 
-    //array with level by array index and all interests at that level value as the value at that index
+    //2D array with level by array index and all interests at that level value as an array at that index
     const [interestsByLevel, setInterestsByLevel] = useState([]); 
 
-    //fetch roots
     useEffect(() => {
         fetchRootInterests();
     }, []);
@@ -17,7 +16,7 @@ const InterestList = () => {
             try {
                 const apiResultData = await APIUtils.fetchRootInterests();
                 const newArr = []; 
-                newArr[0] = apiResultData;
+                newArr[0] = apiResultData; //make first level interests (stored in first index of array) hold all returned root interests
                 setInterestsByLevel(newArr);
             } catch (error) {
                 console.log("Status ", error.status);
@@ -28,7 +27,7 @@ const InterestList = () => {
     const addNewColumn = async (interestId, clickedInterestLevel) => {
         try {
             const apiResultData = await APIUtils.fetchImmediateChildren(interestId);
-            if (apiResultData.length !== 0) { //meaning no children i.e have reached leaf in the tree
+            if (apiResultData.length !== 0) { //have reached leaf in the tree therefore dont render more
                 const newArr = [];
                 for (let i = 0; i < clickedInterestLevel; i++) {
                     newArr[i] = interestsByLevel[i];

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -1,16 +1,45 @@
+import { useState, useEffect, Suspense } from 'react';
 import InterestLevelColumn from "../components/InterestLevelColumn";
+import APIUtils from "../utils/APIUtils";
 import "../styles/InterestList.css";
 
 const InterestList = () => {
+
+    //array with level by array index and all interests at that level value as the value at that index
+    const [interestsByLevel, setInterestsByLevel] = useState([]); 
+
+    //fetch roots
+    useEffect(() => {
+        fetchRootInterests();
+    }, []);
+
+    const fetchRootInterests = async () => {
+            try {
+                const apiResultData = await APIUtils.fetchRootInterests();
+                const newArr = [...interestsByLevel];
+                newArr[0] = apiResultData;
+                setInterestsByLevel(newArr);
+            } catch (error) {
+                console.log("Status ", error.status);
+                console.log("Error: ", error.message);
+            }
+        }
+
+    const addNewColumn = () => {
+        //call setInterestsByLevel => increase by 1 new pair with fetched values
+
+    }
+
     return <div className="interest-list-container">
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
-        <InterestLevelColumn />
+        <Suspense fallback={<p>Loading...</p>}>
+            {interestsByLevel.map((interestsArr, index) => (
+                <InterestLevelColumn 
+                    key={interestsArr[0].id} //use first interest's id in level as level's key.
+                    interests={interestsArr}
+                    onInterestClick={addNewColumn}
+                />
+            ))}
+        </Suspense>
     </div>
 }
 

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -89,4 +89,20 @@ export default class APIUtils {
         }
 
     }
+
+    static fetchRootInterests = async () => {
+        const response = await fetch("http://localhost:3000/interests/", {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
 }

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -105,4 +105,20 @@ export default class APIUtils {
             throw {status: response.status, message: data.error};
         }
     }
+
+    static fetchImmediateChildren = async (interestId) => {
+        const response = await fetch(`http://localhost:3000/interests/${interestId}`, {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
 }

--- a/server/prisma/migrations/20250703212745_added_level_to_interest_table/migration.sql
+++ b/server/prisma/migrations/20250703212745_added_level_to_interest_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `level` to the `Interest` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Interest" ADD COLUMN     "level" INTEGER NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Interest {
   id        Int        @id @default(autoincrement())
   title     String
   parent_id Int?
+  level     Int
   parent    Interest?  @relation("InterestsSubInterests", fields: [parent_id], references: [id])
   children  Interest[] @relation("InterestsSubInterests")
   users     User[]

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -2,16 +2,16 @@ const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
 const interests = [
-    {id: 0, title: 'Music', parent_id: null},
-    {id: 1, title: 'Sports',  parent_id: null},
-    {id: 2, title: 'Cooking',  parent_id: null},
-    {id: 3, title: 'Singing',  parent_id: 0},
-    {id: 4, title: 'Karaoke',  parent_id: 3},
-    {id: 5, title: 'Basketball',  parent_id: 1},
-    {id: 6, title: 'Rock',  parent_id: 0},
-    {id: 7, title: 'Indie Rock',  parent_id: 6},
-    {id: 8, title: 'Hard Rock',  parent_id: 6},
-    {id: 9, title: 'ACDC',  parent_id: 8},
+    {id: 0, title: 'Music', parent_id: null, level: 1},
+    {id: 1, title: 'Sports',  parent_id: null, level: 1},
+    {id: 2, title: 'Cooking',  parent_id: null, level: 1},
+    {id: 3, title: 'Singing',  parent_id: 0, level: 2},
+    {id: 4, title: 'Karaoke',  parent_id: 3, level: 3},
+    {id: 5, title: 'Basketball',  parent_id: 1, level: 2},
+    {id: 6, title: 'Rock',  parent_id: 0, level: 2},
+    {id: 7, title: 'Indie Rock',  parent_id: 6, level: 3},
+    {id: 8, title: 'Hard Rock',  parent_id: 6, level: 3},
+    {id: 9, title: 'ACDC',  parent_id: 8, level: 4},
 ];
 const groups = [
     {title: 'Group Karaoke MPK', description: 'Karaoke Group in Menlo Park', is_full: false, interest_id: 4, latitude: 37.4855, longitude: -122.1500},

--- a/server/routes/interests.js
+++ b/server/routes/interests.js
@@ -44,7 +44,7 @@ router.get('/interests/:interestId', isAuthenticated, async (req, res) => {
             res.status(404).send('This interest does not exist');
         }
 
-        res.status(200).json(interest);
+        res.status(200).json(interest.children); //only send back children
         
 
 

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -14,8 +14,7 @@ const filterGroupsByLocation = async (userLatitude, userLongitude) => {
 
     const groupRecord = await prisma.$queryRaw`SELECT id, title, ST_AsText(coord) FROM "Group" WHERE ST_DWithin(coord, ST_SetSRID(ST_MakePoint(${userLongitude}, ${userLatitude}), 4326)::geography, ${LOCATION_SEARCH_RADIUS}) AND is_full= FALSE`;
     
-    console.log("Groups near User:")
-    console.log(groupRecord);
+    
 }
 
 module.exports = { findGroups };


### PR DESCRIPTION
## Description

Done in this PR:
In this PR I now have the interests loaded onto the "interests" page that I started coding out last time. It fetches and renders the root interests and then when you click on an interest the immediate sub interests are loaded as well.

I used a 2d array structure to store already fetched interests on the frontend and I made it so that children events are only fetched when needed. Please let me know if I should make any adjustments to these for better performance.

Done in upcoming PRs:
-I need to have the selected interest be shaded to make the hierarchy path clearer to the user
-I need to make it so that a user can select an interest and view their selected interests. 
-I also have a modified approach for my first technical challenge so I will be building the algorithm for that on the backend

## Milestones
User can view and navigate interest options.

## Resources
Nothing new, I just used previous React knowledge.

## Test Plan
Example going through Music > Rock > Hard Rock > ACDC

<img width="1509" alt="Screenshot 2025-07-03 at 4 51 14 PM" src="https://github.com/user-attachments/assets/c58cc375-ac7c-4e31-ade5-10ea59cf5c54" />
<img width="1490" alt="Screenshot 2025-07-03 at 4 51 49 PM" src="https://github.com/user-attachments/assets/d455eaf9-0b2f-4387-b02f-792a6479ae18" />
<img width="1492" alt="Screenshot 2025-07-03 at 4 52 03 PM" src="https://github.com/user-attachments/assets/0d78ff68-a540-4159-aa2d-5a177a6a9506" />
<img width="1501" alt="Screenshot 2025-07-03 at 4 52 18 PM" src="https://github.com/user-attachments/assets/170ba988-8b53-4a7f-9918-d0f929763bb4" />

