### PR TITLE
User can now accept groups, which changes the group's data

### DIFF
--- a/client/src/components/InterestTile.jsx
+++ b/client/src/components/InterestTile.jsx
@@ -4,7 +4,7 @@ const InterestTile = ({ interest, onTileClick }) => {
     return ( 
         <div className="interest-tile" onClick={() => {
                 onTileClick(interest.id, interest.level);
-                //add class to change shading
+                // TODO: add class to change shading
             }}>
             <p>{interest.title}</p>
         </div>

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -16,7 +16,7 @@ const InterestList = () => {
             try {
                 const apiResultData = await APIUtils.fetchRootInterests();
                 const newArr = []; 
-                newArr[0] = apiResultData; //make first level interests (stored in first index of array) hold all returned root interests
+                newArr.at(0) = apiResultData; //make first level interests (stored in first index of array) hold all returned root interests
                 setInterestsByLevel(newArr);
             } catch (error) {
                 console.log("Status ", error.status);
@@ -47,7 +47,7 @@ const InterestList = () => {
         <Suspense fallback={<p>Loading...</p>}>
             {interestsByLevel.map((interestsArr) => (
                 <InterestLevelColumn 
-                    key={interestsArr[0].id} //use first interest's id in level as level's key.
+                    key={interestsArr.at(0).id} //use first interest's id in level as level's key.
                     interests={interestsArr}
                     onInterestClick={addNewColumn}
                 />

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -54,7 +54,7 @@ async function main() {
         //for seeding, include interests 
         await prisma.group.update({
             where: {
-                id: groupRecordId[0].id
+                id: groupRecordId.at(0).id
             },
             data: {
                 interests: {
@@ -74,7 +74,7 @@ async function main() {
         //for seeding, include interests - would not be done this way in finished product:
         await prisma.event.update({
             where: {
-                id: eventRecordId[0].id
+                id: eventRecordId.at(0).id
             },
             data: {
                 interest: { connect: event.interest } 

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -51,7 +51,7 @@ async function main() {
     for (const group of groups) {
         const groupRecordId = await prisma.$queryRaw`INSERT INTO "Group" (title, description, is_full, coord) VALUES(${group.title}, ${group.description}, ${group.is_full}, ST_SetSRID(ST_MakePoint(${group.longitude}, ${group.latitude}), 4326)::geography) RETURNING id`;
 
-        //for seeding, include interests - would not be done this way in finished product:
+        //for seeding, include interests 
         await prisma.group.update({
             where: {
                 id: groupRecordId[0].id

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -52,7 +52,7 @@ router.post('/signup', async (req, res) => {
         //for mock data, have all users start out with location at meta's headquarters
         const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${-122.1500}, ${37.485949}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
 
-        const newUser = queryResult[0];
+        const newUser = queryResult.at(0);
         // Store user ID and username in the session, allowing them to remain authenticated as they navigate the website
         req.session.userId = newUser.id
         req.session.username = newUser.username

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const bcrypt = require('bcrypt')
-const { PrismaClient, Prisma } = require('../generated/prisma');
+const { PrismaClient } = require('../generated/prisma');
 
 const prisma = new PrismaClient()
 const router = express.Router()
@@ -50,7 +50,7 @@ router.post('/signup', async (req, res) => {
 
         // Create a new user in the database
         //for mock data, have all users start out with location at meta's headquarters
-        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${-122.1500}, ${37.4855}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
+        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${-122.1500}, ${37.485949}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
 
         const newUser = queryResult[0];
         // Store user ID and username in the session, allowing them to remain authenticated as they navigate the website

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -28,7 +28,7 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
 })
 
 //update user's status for an event
-router.patch('/user/events/:event_id', isAuthenticated, async (req, res) => {
+router.patch('/user/events/:event_id/status', isAuthenticated, async (req, res) => {
     const event_id = parseInt(req.params.event_id);
     const {updatedStatus} = req.body; 
 

--- a/server/routes/interests.js
+++ b/server/routes/interests.js
@@ -55,11 +55,10 @@ router.get('/interests/:interestId', isAuthenticated, async (req, res) => {
 })
 
 //update user interests
-router.post('/interests', isAuthenticated, async (req, res) => {
+router.post('/user/interests', isAuthenticated, async (req, res) => {
     const { chosenInterests } = req.body;
 
     try {
-        //may want to make this a raw query to be able to get coordinates here too.
         const updatedUser = await prisma.user.update({
             where: {
                 id: req.session.userId,

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -94,8 +94,8 @@ const getUserCoordinates = async (userId) => {
     WHERE id = ${userId}`;
     
     return {
-        longitude: userCoord[0].st_x,
-        latitude: userCoord[0].st_y,
+        longitude: userCoord.at(0).st_x,
+        latitude: userCoord.at(0).st_y,
     };
 }
 

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -49,7 +49,6 @@ const getCandidateGroups =  async (allGroupsNearby, allUserInterests) => {
     const interestIds = allUserInterests.map((interest) => {
         return interest.id;
     })
-    
     //get group candidates, filtered by ones nearby and ones that include at least one of the user's extended interests
     let groupCandidates =  await prisma.group.findMany({
         where: {

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -1,6 +1,8 @@
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
+const { getExpandedInterests } = require('./Utils');
+
 const LOCATION_SEARCH_RADIUS = 100; //in meters - will likely put in utils file later because will be used in event finding algo
 
 const findGroups = async (userData) => {
@@ -11,7 +13,7 @@ const findGroups = async (userData) => {
     const groupsByLocation = await filterGroupsByLocation(userCoordinates); 
 
     //expand user's selected interest list to include ancestor interests, so that these are also considered in group matching
-    const expandedUserInterests = await getExpandedUserInterests(userData.interests);
+    const expandedUserInterests = await getExpandedInterests(userData.interests, false);
 
     //get all groups that have at least one matching interest and are near the user
     const candidateGroups = await getCandidateGroups(groupsByLocation, expandedUserInterests);
@@ -26,20 +28,7 @@ const findGroups = async (userData) => {
     candidateGroups.sort((a, b) => b.compatibilityRatio - a.compatibilityRatio );
 
     //return these group suggestions to the user - limit the number sent?
-    return candidateGroups;
-
-    /*CURRENT APPROACH:
-        -For each group (filtered only by ones that include at least one of the user's extended interests and are within radius - AND group interest lists 
-        within each group only contain matching ones), go through group's interest list and tally interests with weighting for each group.
-    */
-    /*ALTERNATIVE APPROACH:
-        -Query the interest table for each interest in extended set and include the groups that include it.
-            -Additionally, these groups would need to be filtered by ones that are within distance requirement.
-        -I could then use this to create inverted index table (using Map) with interest ids as the keys and the list of groups 
-        that contain that interest as the value.
-        -Then for each of those interests and their weights (level attribute) go through each group and tally for jaccard calculation.
-    */
-        
+    return candidateGroups;        
 }
 
 const calcJaccardSimilarity = (group, numUserInterests) => {
@@ -109,38 +98,6 @@ const getUserCoordinates = async (userId) => {
         longitude: userCoord[0].st_x,
         latitude: userCoord[0].st_y,
     };
-}
-
-const getExpandedUserInterests = async (selectedInterests) => {
-    let expandedInterestSet = [];
-
-    for (const interest of selectedInterests) { //Plan is to limit interest selection to 5, so this loop shouldn't have too many iterations
-
-        if (interest.parent_id == null) continue;
-
-        //query for interest ancestry path for each selected interest
-        const path = await prisma.interest.findUnique({
-            where: {id: interest.id},
-            select: {
-                path: true
-            }
-        })
-        
-        //use path field to avoid recursive calls to get entire hierarchy 
-        const pathParsed = path.path.split('.').map((id) => {
-            return parseInt(id);
-        })
-
-        pathParsed.pop(); //don't need to include selected interest again
-
-        //get the actual interest objects of these ancestor ids
-        const ancestorInterests = await prisma.interest.findMany({
-            where: {id: { in: pathParsed}}
-        })
-
-        expandedInterestSet = [...expandedInterestSet, ...ancestorInterests]; //expand user's interest set to now include ancestor interests
-    }
-    return [...selectedInterests, ...expandedInterestSet];
 }
 
 //this will be used in events finding algo as well, so I will likely move this method to a utils file

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -1,0 +1,26 @@
+const { PrismaClient } = require('../generated/prisma');
+const prisma = new PrismaClient()
+
+const { getExpandedInterests } = require('./Utils');
+
+const updateGroupCentralLocation = (groupCoord, userCoord) => {
+   //Given the fact that the accepted group's location and user's location are close by, the midpoint formula is good enough for midpoint calculation:
+   const newLongitude = (groupCoord.st_x + userCoord.st_x) / 2;
+   const newLatitude = (groupCoord.st_y + userCoord.st_y) / 2;
+   return {
+        longitude: newLongitude,
+        latitude: newLatitude
+   }
+}
+
+
+const updateGroupInterests = async (groupInterests, user) => {
+    //this method will create a union set between group's existing interests and user's interests
+    
+    //1) need to extend group's interest set to make sure duplicates aren't included later on
+    const expandedGroupInterests = await getExpandedInterests(groupInterests, true);
+
+}
+
+
+module.exports = { updateGroupCentralLocation, updateGroupInterests };

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { getExpandedInterests } = require('./Utils');
+const { getUnionOfSets } = require('./Utils');
 
 const updateGroupCentralLocation = (groupCoord, userCoord) => {
    //Given the fact that the accepted group's location and user's location are close by, the midpoint formula is good enough for midpoint calculation:
@@ -14,12 +14,13 @@ const updateGroupCentralLocation = (groupCoord, userCoord) => {
 }
 
 
-const updateGroupInterests = async (groupInterests, user) => {
+const updateGroupInterests = async (groupInterests, userInterests) => {
     //this method will create a union set between group's existing interests and user's interests
     
-    //1) need to extend group's interest set to make sure duplicates aren't included later on
-    const expandedGroupInterests = await getExpandedInterests(groupInterests, true);
+    //need to union the expandedGroupInterests set with the user's selected interests set
+    const unionInterests = await getUnionOfSets(groupInterests, userInterests);
 
+    return [...unionInterests]; //return as array, not set object
 }
 
 

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -35,4 +35,16 @@ const getExpandedInterests = async (originalInterests, isGroup) => {
     return [expandedInterestSet];
 }
 
-module.exports = { getExpandedInterests};
+const getUnionOfSets = (groupInterests, userInterests) => {
+    const groupIds = groupInterests.map((group) => {
+        return group.interest.id;
+    })
+    const interestIds = userInterests.map((interest) => {
+        return interest.id;
+    })
+
+    const groupInterestsSet = new Set(groupIds);
+    return groupInterestsSet.union(new Set(interestIds));
+}
+
+module.exports = { getExpandedInterests, getUnionOfSets};

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -1,0 +1,38 @@
+const { PrismaClient } = require('../generated/prisma');
+const prisma = new PrismaClient()
+
+const getExpandedInterests = async (originalInterests, isGroup) => {
+    let expandedInterestSet = [];
+
+    for (const interest of originalInterests) { 
+        let currInterest = interest;
+        if (isGroup) currInterest = interest.interest;
+
+        if (currInterest.parent_id == null) continue;
+
+        //query for interest ancestry path for each original interest
+        const path = await prisma.interest.findUnique({
+            where: {id: currInterest.id},
+            select: {
+                path: true
+            }
+        })
+        
+        //use path field to avoid recursive calls to get entire hierarchy 
+        const pathParsed = path.path.split('.').map((id) => {
+            return parseInt(id);
+        })
+
+        pathParsed.pop(); //don't need to include original interest again
+
+        //get the actual interest objects of these ancestor ids
+        const ancestorInterests = await prisma.interest.findMany({
+            where: {id: { in: pathParsed}}
+        })
+
+        expandedInterestSet = [currInterest, ...expandedInterestSet, ...ancestorInterests]; //expand user's interest set to now include ancestor interests
+    }
+    return [expandedInterestSet];
+}
+
+module.exports = { getExpandedInterests};


### PR DESCRIPTION
## Description

**Done in this PR**
-Users can now accept groups. This updates the group’s central coordinates to be closer to the user, the group’s interest set to be a union with the user’s set, and if the group is now full, it updates that as well.
-Once a group is declared full, it will no longer show up as pending on any user’s account who was invited to it but hasn’t accepted it yet. This will prevent confusion for the user.
-Created Utils.js file in systems folder to hold commonly used methods. Moved extendInterests here from GroupFindAlgo as I thought this may be a method that could be generalized.
-Implemented some feedback from last PR, will continue to do so in future PRs.

**Tradeoffs and complexity considerations**
-In getExpandedInterests (systems/Utils.js), I need to continuously get the parent ids, so that’s why I included the ‘path’ field in my interest table. This may take up a bit more space, but because the depth of the interest tree wouldn’t be extremely deep, this doesn’t seem to be too big of an issue. Also, doing this prevents the need for recursive calls to go up the tree which is a more significant benefit.
-I decided to use a simple midpoint formula for coordinates because they should be guaranteed to be within fairly close proximity to each other. This formula is a simpler calculation than needing to be adjusted for coordinates far away.
-One thing I was debating on was if it is bad practice to have to filter through the members list for users who accepted/are part of the group when needing to check if it is full. The members field supports the Group_User many-to-many relationship so that is the only way to connect groups and users and their status (ACCEPTED, PENDING,  REJECTED). I believe this makes more sense than having three separate fields for users - I am not sure if that would even work in a many-to-many relationship.

**Done in upcoming PRs**
-Event for group finding algorithm
-Need to continue to implement feedback from last PR
-Frontend integration (please note that I will return to implementing PR feedback from the past involving frontend that I have not marked resolved) 


## Milestones
User can accept groups

## Resources
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#nested-reads
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union
https://www.geeksforgeeks.org/javascript/how-to-convert-set-to-array-in-javascript/
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries
https://www.w3schools.com/sql/sql_update.asp
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries

## Test Plan
-Once user accepts group, made sure that the group's coordinates and interest list were adjusted and persisted in the database.
-Tested having max number of users who could accept a group, and made sure that is_full attribute turned to true.
-Tested having some users as 'Pending' for a group and when the group filled up, they were no longer associated with that group.
