### PR TITLE
Integrated Groups page with backend - Relative data now displayed for groups.

### DIFF
--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { LiaUserTimesSolid as RejectedIcon} from "react-icons/lia";//icon for "rejected event"
+import { LiaUserCheckSolid as AcceptedIcon} from "react-icons/lia";//icon for "accepted event"
+import { LiaUserClockSolid as PendingIcon} from "react-icons/lia";//icon for "pending response"
+import GroupDetailsModal from './GroupDetailsModal';
+import { Status } from "../utils/utils";
+import "../styles/Card.css";
+
+
+const Group = ( {groupData, updateGroup}) => {
+    console.log("GROUPDATA: ", groupData);
+    const [isGroupDetailsModalVisible, setIsGroupDetailsModalVisible] = useState(false);
+
+    const { title, description } = groupData; //due to nature of prisma relational queries, event table data is in nested event property
+
+    const renderStatus = () => {
+        switch(groupData.status) {
+            case Status.ACCEPTED: 
+                return <AcceptedIcon className="status-icon"/>
+            case Status.PENDING: 
+                return <PendingIcon className="status-icon"/>
+            case Status.REJECTED:
+                return <RejectedIcon className="status-icon"/>
+        }
+    }
+
+    const openModal = () => {
+        setIsGroupDetailsModalVisible(true)
+    }
+    const closeModal = () => {
+        setIsGroupDetailsModalVisible(false);
+    }
+    
+    return (
+        <>
+        <div className="card" onClick={openModal}>
+            <section className="card-header">
+                {renderStatus()}
+                <h4 className="title">{title}</h4>
+            </section>
+            <p>{description}</p>
+        </div>
+        {isGroupDetailsModalVisible && <GroupDetailsModal onModalClose={closeModal} groupData={groupData} onStatusChange={(newGroupObj) => {updateGroup(newGroupObj)}}/>}
+        </>
+    )
+}
+
+export default Group;

--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -8,10 +8,9 @@ import "../styles/Card.css";
 
 
 const Group = ( {groupData, updateGroup}) => {
-    console.log("GROUPDATA: ", groupData);
     const [isGroupDetailsModalVisible, setIsGroupDetailsModalVisible] = useState(false);
-
-    const { title, description } = groupData; //due to nature of prisma relational queries, event table data is in nested event property
+    const compatibilityRatio = groupData.compatibilityRatio;
+    const { title, description } = groupData.group; 
 
     const renderStatus = () => {
         switch(groupData.status) {
@@ -39,6 +38,8 @@ const Group = ( {groupData, updateGroup}) => {
                 <h4 className="title">{title}</h4>
             </section>
             <p>{description}</p>
+            <h5>Compatibility Ratio: </h5>
+            <p>{compatibilityRatio * 100}%</p>
         </div>
         {isGroupDetailsModalVisible && <GroupDetailsModal onModalClose={closeModal} groupData={groupData} onStatusChange={(newGroupObj) => {updateGroup(newGroupObj)}}/>}
         </>

--- a/client/src/components/GroupDetailsModal.jsx
+++ b/client/src/components/GroupDetailsModal.jsx
@@ -1,24 +1,24 @@
-import { useState } from 'react';
+import { useState, Suspense } from 'react';
 import { Status } from "../utils/utils";
 import APIUtils from '../utils/APIUtils';
 
 import "../styles/Modal.css";
 
-const GroupDetailsModal = ( {onModalClose, eventData, onStatusChange}) => {
+const GroupDetailsModal = ( {onModalClose, groupData, onStatusChange}) => {
     
-    const [statusState, setStatusState] = useState(eventData.status); 
+    const [statusState, setStatusState] = useState(groupData.status); 
 
-    const { id, address, description, title, zip_code } = eventData.event;
+    const { id, title, description, interests, members } = groupData.group;
 
     const handleDropdownChange = (event) => {
         setStatusState(event.target.value);
     }
 
     const handleStatusUpdate = async () => {
-        //put request to change status of event
+        //put request to change status of group
         try {
-            const apiResultData = await APIUtils.updateEventStatus(id, statusState);
-            onStatusChange({...eventData, status: apiResultData.status});
+            const apiResultData = await APIUtils.updateGroupStatus(id, statusState);
+            onStatusChange({...groupData, status: apiResultData.status});
             onModalClose();
         } catch (error) {
             console.log("Status ", error.status);
@@ -33,8 +33,18 @@ const GroupDetailsModal = ( {onModalClose, eventData, onStatusChange}) => {
                     <button className="close-btn" onClick={onModalClose}>X</button>
                     <h4>{title}</h4>
                     <p>{description}</p>
-                    <p>{address}</p>
-                    <p>{zip_code}</p>
+                    <Suspense fallback={<p>Loading Interests...</p>}>
+                        <h5>Interests:</h5>
+                        {interests.map((interest) => (
+                            <p key={interest.interest.id}>{interest.interest.title}</p> 
+                        ))}
+                    </Suspense>
+                    <Suspense fallback={<p>Loading Members...</p>}>
+                        <h5>Members:</h5>
+                        {members.map((member) => (
+                            <p key={member.user.id}>{member.user.username} {member.status}</p> 
+                        ))}
+                    </Suspense>
                     <div className="select-form">
                         <select name="update-sattus" defaultValue={statusState} onChange={handleDropdownChange}>
                             <option disabled value="">Choose status</option>

--- a/client/src/components/GroupDetailsModal.jsx
+++ b/client/src/components/GroupDetailsModal.jsx
@@ -1,23 +1,17 @@
-import { useState, Suspense } from 'react';
-import { Status } from "../utils/utils";
+import { Suspense } from 'react';
 import APIUtils from '../utils/APIUtils';
-
+import StatusForm from './StatusForm';
 import "../styles/Modal.css";
 
 const GroupDetailsModal = ( {onModalClose, groupData, onStatusChange}) => {
     
-    const [statusState, setStatusState] = useState(groupData.status); 
-
     const { id, title, description, interests, members } = groupData.group;
 
-    const handleDropdownChange = (event) => {
-        setStatusState(event.target.value);
-    }
-
-    const handleStatusUpdate = async () => {
+    const handleStatusUpdate = async (statusState) => {
         //put request to change status of group
         try {
             const apiResultData = await APIUtils.updateGroupStatus(id, statusState);
+
             onStatusChange({...groupData, status: apiResultData.status});
             onModalClose();
         } catch (error) {
@@ -45,16 +39,8 @@ const GroupDetailsModal = ( {onModalClose, groupData, onStatusChange}) => {
                             <p key={member.user.id}>{member.user.username} {member.status}</p> 
                         ))}
                     </Suspense>
-                    <div className="select-form">
-                        <select name="update-sattus" defaultValue={statusState} onChange={handleDropdownChange}>
-                            <option disabled value="">Choose status</option>
-                            <option value={Status.PENDING}>{Status.PENDING}</option>
-                            <option value={Status.ACCEPTED}>{Status.ACCEPTED}</option>
-                            <option value={Status.REJECTED}>{Status.REJECTED}</option>
-                        </select>
-                        <button onClick={handleStatusUpdate}>Submit Changes</button>
-                    </div>
-
+                    {/* show form with options accept group or ignore when pending OR show form with only drop group option */}
+                    <StatusForm onSubmitChange={handleStatusUpdate} currStatus={groupData.status}/>
                 </div>
             </div>
         </div>

--- a/client/src/components/GroupDetailsModal.jsx
+++ b/client/src/components/GroupDetailsModal.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Status } from "../utils/utils";
+import APIUtils from '../utils/APIUtils';
+
+import "../styles/Modal.css";
+
+const GroupDetailsModal = ( {onModalClose, eventData, onStatusChange}) => {
+    
+    const [statusState, setStatusState] = useState(eventData.status); 
+
+    const { id, address, description, title, zip_code } = eventData.event;
+
+    const handleDropdownChange = (event) => {
+        setStatusState(event.target.value);
+    }
+
+    const handleStatusUpdate = async () => {
+        //put request to change status of event
+        try {
+            const apiResultData = await APIUtils.updateEventStatus(id, statusState);
+            onStatusChange({...eventData, status: apiResultData.status});
+            onModalClose();
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
+    }
+
+    return (
+        <div className="modal-overlay"> 
+            <div className="modal-popup">       
+                <div className="modal-content">
+                    <button className="close-btn" onClick={onModalClose}>X</button>
+                    <h4>{title}</h4>
+                    <p>{description}</p>
+                    <p>{address}</p>
+                    <p>{zip_code}</p>
+                    <div className="select-form">
+                        <select name="update-sattus" defaultValue={statusState} onChange={handleDropdownChange}>
+                            <option disabled value="">Choose status</option>
+                            <option value={Status.PENDING}>{Status.PENDING}</option>
+                            <option value={Status.ACCEPTED}>{Status.ACCEPTED}</option>
+                            <option value={Status.REJECTED}>{Status.REJECTED}</option>
+                        </select>
+                        <button onClick={handleStatusUpdate}>Submit Changes</button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    )
+
+}
+
+export default GroupDetailsModal;

--- a/client/src/components/StatusForm.jsx
+++ b/client/src/components/StatusForm.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { Status } from "../utils/utils";
+import '../styles/StatusForm.css';
+
+const StatusForm = ({ onSubmitChange, currStatus }) => {
+    const [notif, setNotif] = useState(''); //notification to user if they make an invalid action - in this case pressing submit without changing status
+    let selectedStatus = currStatus;
+
+    const changeSelectedState = (newStatus) => {
+        selectedStatus = newStatus;
+        setNotif('');
+    }
+
+    const handleSubmit = () => {
+        if (selectedStatus === currStatus) {
+            setNotif("You haven't selected anything");
+        } else {
+            onSubmitChange(selectedStatus);
+        }
+        
+    }
+
+    //need to change button options depending on whether the group has already been accepted or not
+    return (
+        <section className="change-status-form">
+            {currStatus === Status.PENDING?<p>You haven't responded to this invite yet.</p> : <p>Click "Drop" if you would like to drop this group.</p> }
+            {currStatus === Status.PENDING&&<button onClick={() => changeSelectedState(Status.ACCEPTED)}>Accept</button>}
+            <button onClick={() => changeSelectedState(Status.REJECTED)}>{currStatus === Status.PENDING? "Ignore": "Drop" }</button>
+            <p>{notif}</p>
+            <button onClick={() => handleSubmit()}>Submit Changes</button>
+        </section>
+        
+    )
+}
+
+export default StatusForm;

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -28,7 +28,7 @@ const GroupsList = () => {
         try {
             const apiResultData = await APIUtils.fetchGroups();
             const mappedGroups = new Map(
-                apiResultData.map(group => [group.group_id, group.group])
+                apiResultData.map(group => [group.group_id, group])
             );
             setGroups(mappedGroups);
         } catch (error) {
@@ -39,7 +39,7 @@ const GroupsList = () => {
 
     return (
         <>
-        <h2>Events</h2>
+        <h2>Groups</h2>
         <FilterOptions onFilterChange={(status) => {setStatusFilter(status)}}/>
         <div className="card-container">
             <Suspense fallback={<p>Loading...</p>}>
@@ -49,7 +49,7 @@ const GroupsList = () => {
                         groupData={value}
                         updateGroup = {(newGroupObj) => {
                             const updatedGroups = new Map(groups);
-                            updatedGroups.set(newGroupObj.id, newGroupObj);
+                            updatedGroups.set(newGroupObj.group_id, newGroupObj);
                             setGroups(updatedGroups);
                         }}
                     />

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -1,10 +1,62 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Suspense } from 'react';
+import { Status } from "../utils/utils";
+import Group from "../components/Group";
+import FilterOptions from "../components/FilterOptions";
+import APIUtils from '../utils/APIUtils';
 import "../styles/CardListContainer.css"
 
 const GroupsList = () => {
+    const [groups, setGroups] = useState(new Map());
+    const [statusFilter, setStatusFilter] = useState(Status.NONE);
+    const displayedGroups = useMemo(
+        () => {
+            if (statusFilter === Status.NONE) return groups;
+            const filteredGroups = Array.from(groups.entries()).filter(([key, value])  => 
+                value.status === statusFilter
+            )
+            return new Map(filteredGroups);
+        },
+        [groups, statusFilter]
+    );
+
+    useEffect(() => {
+        fetchGroups();
+    }, []);
+
+    const fetchGroups = async () => {
+        try {
+            const apiResultData = await APIUtils.fetchGroups();
+            const mappedGroups = new Map(
+                apiResultData.map(group => [group.group_id, group.group])
+            );
+            setGroups(mappedGroups);
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
+    }
+
     return (
+        <>
+        <h2>Events</h2>
+        <FilterOptions onFilterChange={(status) => {setStatusFilter(status)}}/>
         <div className="card-container">
-            <p>groups will show up here</p>
+            <Suspense fallback={<p>Loading...</p>}>
+                {Array.from(displayedGroups.entries()).map(([key, value]) => (
+                    <Group 
+                        key={key}
+                        groupData={value}
+                        updateGroup = {(newGroupObj) => {
+                            const updatedGroups = new Map(groups);
+                            updatedGroups.set(newGroupObj.id, newGroupObj);
+                            setGroups(updatedGroups);
+                        }}
+                    />
+                ))}
+            </Suspense>
         </div>
+        </>
     )
 }
 

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -16,7 +16,7 @@ const InterestList = () => {
             try {
                 const apiResultData = await APIUtils.fetchRootInterests();
                 const newArr = []; 
-                newArr.at(0) = apiResultData; //make first level interests (stored in first index of array) hold all returned root interests
+                newArr[0] = apiResultData; //make first level interests (stored in first index of array) hold all returned root interests
                 setInterestsByLevel(newArr);
             } catch (error) {
                 console.log("Status ", error.status);

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -2,7 +2,27 @@
 export default class APIUtils {
 
     static updateEventStatus = async (id, statusState) => {
-        const response = await fetch(`http://localhost:3000/user/events/${id}`, { //path param is event id
+        const response = await fetch(`http://localhost:3000/user/events/${id}/status`, { //path param is event id
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                "updatedStatus": statusState
+            }),
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+   
+    }
+
+    static updateGroupStatus = async (id, statusState) => {
+        const response = await fetch(`http://localhost:3000/user/groups/${id}/status`, { //path param is group id
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -90,6 +90,24 @@ export default class APIUtils {
 
     }
 
+    static fetchGroups = async () => {
+        const response = await fetch("http://localhost:3000/user/groups/", {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+
+    }
+
+
     static fetchRootInterests = async () => {
         const response = await fetch("http://localhost:3000/interests/", {
             method: "GET",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -75,11 +75,12 @@ model Event_User {
 }
 
 model Group_User {
-  user_id  Int
-  group_id Int
-  status   Status @default(PENDING)
-  group    Group  @relation(fields: [group_id], references: [id])
-  user     User   @relation(fields: [user_id], references: [id])
+  user_id             Int
+  group_id            Int
+  status              Status @default(PENDING)
+  compatibilityRatio  Decimal @default("0.00")
+  group    Group      @relation(fields: [group_id], references: [id])
+  user     User       @relation(fields: [user_id], references: [id])
 
   @@id([user_id, group_id])
 }

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -19,7 +19,7 @@ router.get('/user/groups/', isAuthenticated, async (req, res) => {
                 id: req.session.userId, 
             },
             include: { 
-                groups: {include: {group: { include: {interests: true, members: true}}}}
+                groups: {include: {group: { include: {interests: {include: {interest: true}}, members: {where: {NOT: {user_id: req.session.userId}}, include: {user: true}}}}}}
             }
         })
         res.status(201).json(userData.groups)
@@ -98,7 +98,8 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
                     data: {
                         group: {connect: {id: group.id} },
                         user: {connect: {id: req.session.userId} },
-                        status: Status.PENDING 
+                        status: Status.PENDING, 
+                        compatibilityRatio: group.compatibilityRatio 
                     }
                 })
             }

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -22,7 +22,7 @@ router.get('/user/groups/', isAuthenticated, async (req, res) => {
                 groups: {include: {group: { include: {interests: true, members: true}}}}
             }
         })
-        res.status(201).json(userData)
+        res.status(201).json(userData.groups)
     } catch (error) {
         console.error("Error fetching groups:", error)
         res.status(500).json({ error: "Something went wrong while fetching groups." })

--- a/server/systems/EventFindAlgo.js
+++ b/server/systems/EventFindAlgo.js
@@ -1,5 +1,5 @@
 /*On trigger (manual for now) - maybe run algo once a day?
-1)Get events 
+1)Get events
 2)For each event filter groups nearby that include the event's core interest
 3)Send event invites to these groups and all users within them.
 */

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -20,7 +20,7 @@ const findGroups = async (userData) => {
     
     //for each of the possible groups, calculate the jaccard similarity to user's interests
     for (let i = 0; i < candidateGroups.length; i++) {
-        const compatibilityRatio = calcJaccardSimilarity(candidateGroups[i], expandedUserInterests.length);
+        const compatibilityRatio = calcJaccardSimilarity(candidateGroups[i], expandedUserInterests.length).toFixed(2);
         candidateGroups[i] = {...candidateGroups[i], compatibilityRatio: compatibilityRatio}
     }
 


### PR DESCRIPTION
## Description

**Done in this PR**
-In this PR I have integrated the 'Groups' tab/page on the frontend with the 'get groups' and 'update group status' endpoints on the backend. **GroupsList, Group component, and GroupDetailsModal were all very similar to previously implemented event components.**
-I also noted some limitations with the current dropdown method for updating status, so I created a StatusForm react component with buttons and text depending on whether the group was accepted or not yet.

-NOTE: Although not implemented now, the goal is that once a group is dropped or ignored, it will disappear from user's screen

**Done in upcoming PRs**
-I need to use my new StatusForm component to the events page as well.
-Connect 'accept group' endpoint to the frontend 
-Create 'drop group' and 'ignore group' endpoints on the backend and integrate with frontend
-Integrate interests page so that users can select and change interests
-Improve styling - especially having buttons shaded when clicked

## Milestones
User can see, filter, accept, and reject group invites.

## Resources
https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types
https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting

## Test Plan
<img width="1574" alt="Screenshot 2025-07-08 at 11 30 45 PM" src="https://github.com/user-attachments/assets/b7b95179-4f11-44fc-9352-268acf6144c0" />
When group is still not accepted:
<img width="1573" alt="Screenshot 2025-07-08 at 11 32 29 PM" src="https://github.com/user-attachments/assets/f63945d2-bc83-4cf4-a51e-348f348e47b2" />
After accepting group 1:
<img width="1576" alt="Screenshot 2025-07-08 at 11 31 48 PM" src="https://github.com/user-attachments/assets/b5209843-2b22-474d-992f-908c21b33d1b" />

