### PR TITLE
Groups are filtered down by event (proximity, interest, previous invite status) and new Group_Event entries are created

### DIFF
--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -4,7 +4,8 @@ const router = express.Router()
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { isAuthenticated } = require('../middleware/CheckAutheticated')
+const { isAuthenticated } = require('../middleware/CheckAutheticated');
+const { scheduleEventsForGroups } = require('../systems/EventFindAlgo');
 
 //get user's events 
 router.get('/user/events/', isAuthenticated, async (req, res) => {
@@ -64,6 +65,17 @@ router.patch('/user/events/:event_id/status', isAuthenticated, async (req, res) 
         console.error("Error fetching events:", error)
         res.status(500).json({ error: "Could not update your response to this event." });
     }
+})
+
+//start event search for groups
+router.get('/events/search', isAuthenticated, async (req, res) => {
+   try {
+       const allEvents = await scheduleEventsForGroups();
+       res.status(200).json(allEvents);
+   } catch (error) {
+       console.error("Error fetching events:", error)
+       res.status(500).json({ error: "Could not get events." });
+   }
 })
 
 

--- a/server/systems/EventFindAlgo.js
+++ b/server/systems/EventFindAlgo.js
@@ -15,7 +15,7 @@ const scheduleEventsForGroups = async () => {
         //for this event, find groups within location range
         const groupsNearby = await filterGroupsByLocation(eventCoords, true);
 
-        //for these groups, additionally filter by ones that include this event's interest in their array of interests
+        //for these groups, additionally filter by ones that include this event's interest in their array of interests AND haven't been sent this event invite yet
         const candidateGroups = await getCandidateGroups(groupsNearby, retrievedEvent.interest_id, retrievedEvent.id);
         for (group of candidateGroups) {
             const inviteStatus = sendInvitesToUsers();

--- a/server/systems/EventFindAlgo.js
+++ b/server/systems/EventFindAlgo.js
@@ -1,5 +1,97 @@
-/*On trigger (manual for now) - maybe run algo once a day?
-1)Get events
-2)For each event filter groups nearby that include the event's core interest
-3)Send event invites to these groups and all users within them.
-*/
+const { PrismaClient } = require('../generated/prisma');
+const prisma = new PrismaClient()
+
+const { filterGroupsByLocation } = require('./Utils');
+
+const scheduleEventsForGroups = async () => {
+    //get all events from Event table that have not passed - this method also filters out events from the database that have passed
+    const allEvents = await getAllEvents();
+
+    for (retrievedEvent of allEvents) {
+        const eventCoords = {
+            longitude: retrievedEvent.st_x,
+            latitude: retrievedEvent.st_y,
+        }
+        //for this event, find groups within location range
+        const groupsNearby = await filterGroupsByLocation(eventCoords, true);
+
+        //for these groups, additionally filter by ones that include this event's interest in their array of interests
+        const candidateGroups = await getCandidateGroups(groupsNearby, retrievedEvent.interest_id, retrievedEvent.id);
+        for (group of candidateGroups) {
+            const inviteStatus = sendInvitesToUsers();
+            if (inviteStatus === 200) {
+                //invites sent, now update group_event table
+                await createGroup_Event(group.id, retrievedEvent.id);
+
+                // TODO: also update user_event tables for each user in the group
+
+            } else {
+                throw Error("Invites failed to send");
+            }
+
+        }
+    }
+    return allEvents;
+}
+
+const createGroup_Event = async (groupId, eventId) => {
+    return await prisma.group_Event.create({ 
+        data: {
+            group: { connect: { id: groupId } },
+            event: { connect: { id: eventId } }
+        }
+    })
+}
+
+const sendInvitesToUsers = () => {
+    // TODO: will implement public api for sending invites soon, for now just return 200 to mock 200 ok status
+    return (200);
+}
+
+const getCandidateGroups = async (allGroupsNearby, eventInterest, eventId) => {
+    const groupIds = allGroupsNearby.map((group) => {
+        return group.id;
+    })
+
+    return await prisma.group.findMany({
+        where: {
+            id: { in: groupIds },
+            interests: {
+                some: {
+                    interest_id: eventInterest
+                }
+            },
+            events: {
+                none: {
+                    event_id: eventId,
+                },
+            }
+        },
+        include: {
+            interests: {
+                select: { interest: { select: { level: true, title: true } } }
+            }
+        }
+    });
+}
+
+const getAllEvents = async () => {
+    const currDate = new Date();
+
+    //clear out events from database that have passed
+    await prisma.event.deleteMany({
+        where: {
+            dateTime : {
+                lt: currDate
+            }
+        },
+    })
+
+    //return upcoming events - should be what's left
+    return await prisma.$queryRaw`
+   SELECT ST_X(coord::geometry), ST_Y(coord::geometry), "id", "title", "description", "dateTime", "interest_id" FROM "Event"`;
+
+
+}
+
+module.exports = { scheduleEventsForGroups };


### PR DESCRIPTION
## Description

**Done in this PR**
-Created endpoint in events.js that starts EventFindAlgo. Inside of EventFindAlgo, for each event retrieved from the database, groups are filtered by proximity, if it contains the event interest, and if it has not been invited to this event before. New Group_Event relations are then created for these groups in the database.

**Tradeoffs and complexity considerations**
-Note: I made it so that events are defined by a singular interest. It is unlikely for an event to be classified by more than one, but if that were to occur in future developments of the project, that would be an easy adjustment.
-I had two options: for each group, find possible events OR for each event, find possible groups. I am not sure if the decision between the two would have mattered significantly but I decided on going through each event in the database that has not already passed and getting the possible groups. With this approach, Gist indexing wouldn’t need to be added to the Events table, and because events are only defined by one interest, group interest lists just have to be checked against one. If it was the other way around, each event would have to be checked against multiple group interests.

-However, I definitely feel that this event search algorithm can be optimized more, especially when it comes to figuring out how and how often I need to trigger it. Below are some ideas I have thought of, please let me know if any are worth implementing for optimization, or if there are any other ways.
-Can limit the …
-amount of groups an event would be sent to.
-amount of events to send to a group at a time
-minimum number of members that must be in the group to start getting events.
-time window to store events. Ex: in database only store events within 2 weeks from today
-amount of events gone through in a call - maybe trigger in batches?

**Done in upcoming PRs**
-Send invites to individual users in the group (i.e. create entries in the Event_User table) so that they will show up on their events page on the frontend.
-Implementing a public api to send invites (likely email, maybe message). Please let me know any good options you may know.

## Milestones
-Events are found for groups based on proximity and relative interests

## Resources
https://www.prisma.io/docs/orm/prisma-client/queries/crud#delete
https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries

## Test Plan
-Once the newly created endpoint in events.js is triggered, the newly created Group_Event entries are added into the database. This signifies a sent invite. 
-I also had a mock event that passed and a mock event that was way too far away - neither of these showed up in the Group_Event table. (the passed event is filtered out of the Event table altogether)

Event table:
<img width="1013" alt="Screenshot 2025-07-09 at 11 46 59 AM" src="https://github.com/user-attachments/assets/4c507631-1cd5-4868-8c97-e0be1e17d1f2" />
Group_Event table:
<img width="311" alt="Screenshot 2025-07-09 at 11 47 37 AM" src="https://github.com/user-attachments/assets/4e9cc03a-6cfd-488b-a802-280cad7ddf84" />



