### PR TITLE
Endpoint for user drops group created with accept group endpoint now integrated in frontend.

### DIFF
--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -38,8 +38,12 @@ const Group = ( {groupData, updateGroup}) => {
                 <h4 className="title">{title}</h4>
             </section>
             <p>{description}</p>
-            <h5>Compatibility Ratio: </h5>
-            <p>{compatibilityRatio * 100}%</p>
+            {groupData.status !== Status.ACCEPTED&&
+                <section className="compatibility-display">
+                    <h5>Compatibility Ratio: </h5>
+                    <p>{compatibilityRatio * 100}%</p>
+                </section>
+            }
         </div>
         {isGroupDetailsModalVisible && <GroupDetailsModal onModalClose={closeModal} groupData={groupData} onStatusChange={(newGroupObj) => {updateGroup(newGroupObj)}}/>}
         </>

--- a/client/src/components/GroupDetailsModal.jsx
+++ b/client/src/components/GroupDetailsModal.jsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { Status } from "../utils/utils";
 import APIUtils from '../utils/APIUtils';
 import StatusForm from './StatusForm';
 import "../styles/Modal.css";
@@ -12,6 +13,13 @@ const GroupDetailsModal = ( {onModalClose, groupData, onStatusChange}) => {
         try {
             const apiResultData = await APIUtils.updateGroupStatus(id, statusState);
             onStatusChange({...groupData, status: apiResultData.status});
+            if (statusState === Status.ACCEPTED) {
+                const apiResultData = await APIUtils.acceptGroup(id);
+                onStatusChange(apiResultData);
+            } else {
+                const apiResultData = await APIUtils.updateGroupStatus(id, statusState);
+                onStatusChange({...groupData, status: apiResultData.status});
+            } 
             onModalClose();
         } catch (error) {
             console.log("Status ", error.status);

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -127,6 +127,23 @@ export default class APIUtils {
 
     }
 
+    static acceptGroup = async (id) => {
+
+        const response = await fetch(`http://localhost:3000/user/groups/${id}/accept`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
+
 
     static fetchRootInterests = async () => {
         const response = await fetch("http://localhost:3000/interests/", {

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -191,7 +191,8 @@ router.put('/user/groups/:groupId/accept', isAuthenticated, async (req, res) => 
            },
            data: {
                status: Status.ACCEPTED 
-           }
+           },
+           include: {group: {include: {interests: {include: {interest: true}}, members: {where: {NOT: {user_id: req.session.userId}}, include: {user: true}}}}}
        })
 
        //if group is now full, remove it as a "Pending" option from users' lists who have not accepted the group
@@ -211,7 +212,7 @@ router.put('/user/groups/:groupId/accept', isAuthenticated, async (req, res) => 
        }
 
 
-       res.status(200).json(updatedGroup);
+       res.status(200).json(updatedGroupUser);
 
 
    } catch (error) {
@@ -219,5 +220,4 @@ router.put('/user/groups/:groupId/accept', isAuthenticated, async (req, res) => 
        res.status(500).json({ error: "Could not update your response to this group." });
    }
 })
-
 module.exports = router

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -6,20 +6,20 @@ const prisma = new PrismaClient();
 
 const { isAuthenticated } = require('../middleware/CheckAutheticated')
 const { findGroups } = require('../systems/GroupFindAlgo');
-const { updateGroupCentralLocation, updateGroupInterests } = require('../systems/GroupUpdateMethods')
+const { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation } = require('../systems/GroupUpdateMethods')
 const { Status, filterMembersByStatus } = require('../systems/Utils');
 
-const FULL_GROUP_SIZE = 3;
+const FULL_GROUP_SIZE = 10;
 
 //get user's groups 
 router.get('/user/groups/', isAuthenticated, async (req, res) => {
     try {
         const userData = await prisma.user.findUnique({
             where: {
-                id: req.session.userId, 
+                id: req.session.userId,
             },
-            include: { 
-                groups: {include: {group: { include: {interests: {include: {interest: true}}, members: {where: {NOT: {user_id: req.session.userId}}, include: {user: true}}}}}}
+            include: {
+                groups: { include: { group: { include: { interests: { include: { interest: true } }, members: { where: { NOT: { user_id: req.session.userId } }, include: { user: true } } } } } }
             }
         })
         res.status(201).json(userData.groups)
@@ -32,7 +32,7 @@ router.get('/user/groups/', isAuthenticated, async (req, res) => {
 //update user's status for a group
 router.patch('/user/groups/:groupId/status', isAuthenticated, async (req, res) => {
     const groupId = parseInt(req.params.groupId);
-    const {updatedStatus} = req.body; 
+    const { updatedStatus } = req.body;
 
     try {
         const isGroup_user = await prisma.group_User.findUnique({
@@ -45,7 +45,7 @@ router.patch('/user/groups/:groupId/status', isAuthenticated, async (req, res) =
         });
 
         if (!isGroup_user) {
-            res.status(404).json({error: 'This user - group relationship does not exist'});
+            res.status(404).json({ error: 'This user - group relationship does not exist' });
         }
 
         const updatedGroup = await prisma.group_User.update({
@@ -70,16 +70,16 @@ router.patch('/user/groups/:groupId/status', isAuthenticated, async (req, res) =
 
 //get new group suggestions - will be called immediately after user updates their interests
 router.get('/user/groups/new', isAuthenticated, async (req, res) => {
-    
+
 
     try {
         const updatedUser = await prisma.user.findUnique({
-                where: {id: req.session.userId},
-                select: {id: true, interests: true}
+            where: { id: req.session.userId },
+            select: { id: true, interests: true }
         });;
         //Call GroupFindAlgo, will return all suggested groups sorted by compatibility
         const suggestedGroups = await findGroups(updatedUser); //NOTE: the interests attribute part of the returned objects won't be entirely accurate - not needed for now though
-        
+
         //update the user_group table with these invites
         for (group of suggestedGroups) {
 
@@ -96,16 +96,16 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
             if (!isGroup_user) {
                 await prisma.group_User.create({
                     data: {
-                        group: {connect: {id: group.id} },
-                        user: {connect: {id: req.session.userId} },
-                        status: Status.PENDING, 
-                        compatibilityRatio: group.compatibilityRatio 
+                        group: { connect: { id: group.id } },
+                        user: { connect: { id: req.session.userId } },
+                        status: Status.PENDING,
+                        compatibilityRatio: group.compatibilityRatio
                     }
                 })
             }
-            
+
         }
-        
+
         res.status(201).json(suggestedGroups)
     } catch (error) {
         console.error("Error fetching groups:", error)
@@ -116,87 +116,85 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
 //accept group - first, the endpoint above will be called, then this endpoint will be called
 //update user's status for a group
 router.put('/user/groups/:groupId/accept', isAuthenticated, async (req, res) => {
-   const groupId = parseInt(req.params.groupId);
+    const groupId = parseInt(req.params.groupId);
 
 
-   try {
+    try {
         //get group and user relationship and each of their coordinates
-       const group_user = await prisma.group_User.findUnique({
-           where: {
-               user_id_group_id: {
-                   group_id: groupId,
-                   user_id: req.session.userId
-               }
-           },
-           include: {
-               group: { include: {interests: {select: {interest: true}}, members: true}},
-               user: { include: {interests: true} }
-           }
-       });
-       const userCoord = await prisma.$queryRaw`
+        const group_user = await prisma.group_User.findUnique({
+            where: {
+                user_id_group_id: {
+                    group_id: groupId,
+                    user_id: req.session.userId
+                }
+            },
+            include: {
+                group: { include: { interests: { select: { interest: true } }, members: true } },
+                user: { include: { interests: true } }
+            }
+        });
+        const userCoord = await prisma.$queryRaw`
         SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
         FROM "User" 
         WHERE id = ${req.session.userId}`;
-       const groupCoord = await prisma.$queryRaw`
+        const groupCoord = await prisma.$queryRaw`
         SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
         FROM "Group" 
         WHERE id = ${groupId}`;
 
+        if (!group_user) {
+            res.status(404).json({ error: 'This user - group relationship does not exist' });
+        }
 
+        //now that user accepted this group, we need to update the group's interest list and central location
 
-       if (!group_user) {
-           res.status(404).json({error: 'This user - group relationship does not exist'});
-       }
+        const newGroupCoords = updateGroupCentralLocation(groupCoord.at(0), userCoord.at(0));
+        const newGroupInterests = await updateGroupInterests(group_user.group.interests, group_user.user.interests);
 
-       //now that user accepted this group, we need to update the group's interest list and central location
+        const acceptedMembers = filterMembersByStatus(group_user.group.members, Status.ACCEPTED);
+        let newIsFullStatus = false;
 
-       const newGroupCoords = updateGroupCentralLocation(groupCoord.at(0), userCoord.at(0));
-       const newGroupInterests = await updateGroupInterests(group_user.group.interests, group_user.user.interests);
-
-       const acceptedMembers = filterMembersByStatus(group_user.group.members, Status.ACCEPTED);
-       let newIsFullStatus = false;
-
-       if (acceptedMembers.length + 1 >= FULL_GROUP_SIZE) {
+        if (acceptedMembers.length + 1 >= FULL_GROUP_SIZE) {
             newIsFullStatus = true;
-       }
-       
-       //update group in database (update if is now full, update coordinates, update interests list)
-       const updatedGroup = await prisma.group.update({
-            where: {id: groupId},
+        }
+//
+        //update group in database (update if is now full, update coordinates, update interests list)
+        const updatedGroup = await prisma.group.update({
+            where: { id: groupId },
             data: {
-                 interests: {
+                interests: {
                     deleteMany: {},
                     create: newGroupInterests.map((interest) => {
-                        return { interest: { connect: {id: interest} } }
+                        return { interest: { connect: { id: interest } } }
                     })
-                 },
-                 is_full: newIsFullStatus
-             },
-       })
+                },
+                is_full: newIsFullStatus
+            },
+        })
 
-       //update group coordinates
-       await prisma.$queryRaw`
-       UPDATE "Group" 
-       SET "coord" = (ST_SetSRID(ST_MakePoint(${newGroupCoords.longitude}, ${newGroupCoords.latitude}), 4326)::geography)
-       WHERE id=${groupId}`;
+        //update group coordinates
+        await prisma.$queryRaw`
+        UPDATE "Group" 
+        SET "coord" = (ST_SetSRID(ST_MakePoint(${newGroupCoords.st_x}, ${newGroupCoords.st_y}), 4326)::geography)
+        WHERE id=${groupId}`;
 
 
-       //update status of group_user relationship
-       const updatedGroupUser = await prisma.group_User.update({
-           where: {
-               user_id_group_id: {
-                   group_id: groupId,
-                   user_id: req.session.userId
-               }
-           },
-           data: {
-               status: Status.ACCEPTED 
-           },
-           include: {group: {include: {interests: {include: {interest: true}}, members: {where: {NOT: {user_id: req.session.userId}}, include: {user: true}}}}}
-       })
+        //update status of group_user relationship
+        const updatedGroupUser = await prisma.group_User.update({
+            where: {
+                user_id_group_id: {
+                    group_id: groupId,
+                    user_id: req.session.userId
+                }
+            },
+            data: {
+                status: Status.ACCEPTED
+            },
+            include: { group: { include: { interests: { include: { interest: true } }, members: { where: { NOT: { user_id: req.session.userId } }, include: { user: true } } } } }
+        })
 
-       //if group is now full, remove it as a "Pending" option from users' lists who have not accepted the group
-       if (newIsFullStatus) {
+        //if group is now full, remove it as a "Pending" option from users' lists who have not accepted the group
+        if (newIsFullStatus) {
             await prisma.group.update({
                 where: {
                     id: groupId
@@ -209,15 +207,73 @@ router.put('/user/groups/:groupId/accept', isAuthenticated, async (req, res) => 
                     }
                 }
             });
-       }
+        }
 
 
-       res.status(200).json(updatedGroupUser);
+        res.status(200).json(updatedGroupUser);
 
 
-   } catch (error) {
-       console.error("Error updating group:", error)
-       res.status(500).json({ error: "Could not update your response to this group." });
-   }
+    } catch (error) {
+        console.error("Error updating group:", error)
+        res.status(500).json({ error: "Could not update your response to this group." });
+    }
 })
+
+//drop group
+router.put('/user/groups/:groupId/drop', isAuthenticated, async (req, res) => {
+    const groupId = parseInt(req.params.groupId);
+    try {
+        //get group and user relationship
+        const group_user = await prisma.group_User.findUnique({
+            where: {
+                user_id_group_id: {
+                    group_id: groupId,
+                    user_id: req.session.userId
+                }
+            },
+            include: {
+                group: { include: { interests: { select: { interest: true } }, members: { where: { NOT: { user_id: req.session.userId } } } }},
+                user: { include: { interests: true } }
+            }
+        });
+
+        if (!group_user) {
+            res.status(404).json({ error: 'This user - group relationship does not exist' });
+        }
+        
+        //filter to only users that actaully accepted the group
+        const acceptedMembers = group_user.group.members.filter((user) => {
+            return user.status === Status.ACCEPTED;
+        })
+ 
+        //TODO: update group interests with member removal
+        //if group is now empty with removal of this user, remove the group
+        if (acceptedMembers.length === 0) { //remember, user is already excluded for list from db query - so should check against 0
+            await prisma.group.delete({
+                where: { id: groupId }
+            })
+        } else {
+            //recalculate group's central location
+
+            const memberIds = acceptedMembers.map((member) => {
+                return member.user_id
+            })
+
+            const memberCoords = await prisma.$queryRaw`
+            SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
+            FROM "User" 
+            WHERE id = ANY(${(memberIds)})`;
+
+            const newGroupCoords = await recalculateGroupCentralLocation(memberCoords);
+
+        }
+        res.status(200).json({});
+
+    } catch (error) {
+        console.error("Error updating group:", error)
+        res.status(500).json({ error: "Could not update your response to this group." });
+    }
+})
+
+
 module.exports = router

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -25,7 +25,7 @@ const updateGroupInterests = async (groupInterests, userInterests) => {
 const recalculateGroupCentralLocation = async (memberCoords) => {
     let currGroupCoord = memberCoords.at(0)
     for(let i = 1; i < memberCoords.length; i++) {
-        currGroupCoord = updateGroupCentralLocation(currGroupCoord, members[i].coord)
+        currGroupCoord = updateGroupCentralLocation(currGroupCoord, memberCoords.at(i))
     }
     return currGroupCoord;
 }
@@ -44,7 +44,7 @@ const recalculateGroupInterests = async (members, groupInterests) => {
     //for all group interests, check map if it exists. If not, remove the interest
     for (interest of groupInterests) {
         if (interestsToKeep.has(interest.interest.id)) {
-            newGroupInterests.push(interest);
+            newGroupInterests.push(interest.interest);
         }
     }
 

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -30,5 +30,26 @@ const recalculateGroupCentralLocation = async (memberCoords) => {
     return currGroupCoord;
 }
 
+const recalculateGroupInterests = async (members, groupInterests) => {
+    //go through all members' interests (not including current user trying to drop out) and create a set of interest ids
+    const interestsToKeep = new Set();
 
-module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation };
+    for (member of members) {
+        for (interest of member.user.interests) {
+            interestsToKeep.add(interest.id)
+        }
+    }
+            
+    let newGroupInterests = [];
+    //for all group interests, check map if it exists. If not, remove the interest
+    for (interest of groupInterests) {
+        if (interestsToKeep.has(interest.interest.id)) {
+            newGroupInterests.push(interest);
+        }
+    }
+
+    return newGroupInterests;
+}
+
+
+module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation, recalculateGroupInterests };

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -8,11 +8,10 @@ const updateGroupCentralLocation = (groupCoord, userCoord) => {
    const newLongitude = (groupCoord.st_x + userCoord.st_x) / 2;
    const newLatitude = (groupCoord.st_y + userCoord.st_y) / 2;
    return {
-        longitude: newLongitude,
-        latitude: newLatitude
+        st_x: newLongitude,
+        st_y: newLatitude
    }
 }
-
 
 const updateGroupInterests = async (groupInterests, userInterests) => {
     //this method will create a union set between group's existing interests and user's interests
@@ -23,5 +22,13 @@ const updateGroupInterests = async (groupInterests, userInterests) => {
     return [...unionInterests]; //return as array, not set object
 }
 
+const recalculateGroupCentralLocation = async (memberCoords) => {
+    let currGroupCoord = memberCoords.at(0)
+    for(let i = 1; i < memberCoords.length; i++) {
+        currGroupCoord = updateGroupCentralLocation(currGroupCoord, members[i].coord)
+    }
+    return currGroupCoord;
+}
 
-module.exports = { updateGroupCentralLocation, updateGroupInterests };
+
+module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation };


### PR DESCRIPTION
## Description

**Done in this PR:**
-accept group endpoint (from a previous PR) integrated with frontend 
-created drop group endpoint in backend and performed the following group adjustments when user leaves group:
	-recalculate group central coordinates
	-filter out user interests unique to that user from the collective group interests
-data updates for group and user_group relationship are saved to database

**Tradeoffs and complexity considerations**
-For group coordinate recalculations, I did an iterative approach of going through all members’ coordinates still part of the group and finding the midpoint between them, using that midpoint as the group’s central location in the next round of the loop. I decided to do this approach rather than using a PostGIS function (likely would have been ST_GeometricMedian) because the max member size for a group is only 10, so a simpler midpoint calculation would be more suitable than having indexing and database fetching for the users table. Also, because these coordinates are guaranteed to be in proximity to each other, the midpoint formula should give an accurate result.
-For group interest filtering, I decided to go through all members (excluding the one dropping the group) and use a JS Set to store the collective interests of them. Note: The 2 nested for loops here shouldn’t be too much of a concern because the number of members in a group and interests per user are limited. Then, I just went through each group interest and checked the set (O(1) time). If it is not there, that means it was an interest belonging to the user dropping, so filter out that interest.

**Done in upcoming PRs:**
-Integrate drop group endpoint with frontend
-finish integrating interests page so user can update interests and get new group recommendations
-continue to implement frontend-focused feedback

## Milestones
-user can accept groups and drop groups

## Resources
https://www.w3schools.com/sql/sql_any_all.asp
https://community.retool.com/t/how-do-i-use-a-js-array-from-a-sql-query-result-in-a-second-querys-where-in-clause/15447/4
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set

## Test Plan
Click accept in modal...:
<img width="1460" height="713" alt="Screenshot 2025-07-10 at 11 21 49 PM" src="https://github.com/user-attachments/assets/96c6c20d-d21a-4f49-9693-79eda4c07cff" />

...Shows up on screen now:
<img width="1461" height="710" alt="Screenshot 2025-07-10 at 11 22 41 PM" src="https://github.com/user-attachments/assets/4966d4b1-d878-4617-9da7-569c4051464c" />

For the drop endpoint, tested by making sure that group_user status changed to 'REJECTED' in DB and group interests and coordinates changed accordingly.