### PR TITLE
Fully integrated interests page and new group results trigger

### DIFF
--- a/client/src/components/Event.jsx
+++ b/client/src/components/Event.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { LiaUserTimesSolid as RejectedIcon} from "react-icons/lia";//icon for "rejected event"
-import { LiaUserCheckSolid as AcceptedIcon} from "react-icons/lia";//icon for "accepted event"
-import { LiaUserClockSolid as PendingIcon} from "react-icons/lia";//icon for "pending response"
+import { LiaUserTimesSolid as RejectedIcon} from "react-icons/lia";//icon for "rejected/ignored"
+import { LiaUserCheckSolid as AcceptedIcon} from "react-icons/lia";//icon for "accepted"
+import { LiaUserClockSolid as PendingIcon} from "react-icons/lia";//icon for "pending"
+import { FaRunning as DroppedIcon} from "react-icons/fa"; //icon for "dropped"
 import EventDetailsModal from './EventDetailsModal';
 import { Status } from "../utils/utils";
 import "../styles/Card.css";
@@ -14,7 +15,8 @@ const Event = ( {eventData, updateEvent}) => {
     const { title, description, dateTime } = eventData.event; //due to nature of prisma relational queries, event table data is in nested event property
 
     const eventDateTime = (new Date(dateTime)).toDateString();
-    const renderStatus = () => {
+    
+     const renderStatus = () => {
         switch(eventData.status) {
             case Status.ACCEPTED: 
                 return <AcceptedIcon className="status-icon"/>
@@ -22,6 +24,9 @@ const Event = ( {eventData, updateEvent}) => {
                 return <PendingIcon className="status-icon"/>
             case Status.REJECTED:
                 return <RejectedIcon className="status-icon"/>
+            case Status.DROPPED:
+                return <DroppedIcon className="status-icon"/>
+
         }
     }
 

--- a/client/src/components/SelectedInterests.jsx
+++ b/client/src/components/SelectedInterests.jsx
@@ -8,12 +8,19 @@ const SelectedInterests = ({ initialInterests, onSubmitInterests }) => {
         <>
             <h4>Your current interests:</h4>
             <div className="selected-interests-section">
-                <Suspense fallback={<p>Loading...</p>}>
-                    {Array.from(initialInterests.entries()).map( ([key, value]) => (
-                        <SingularSelectedInterest key={key} interest={value}/>
-                    ))}
-                </Suspense>
-                <button className="submit-changes-btn" onClick={onSubmitInterests}>Submit changes</button>
+                {initialInterests.size>0?
+                    <>
+                        <Suspense fallback={<p>Loading...</p>}>
+                            {Array.from(initialInterests.entries()).map( ([key, value]) => (
+                                <SingularSelectedInterest key={key} interest={value}/>
+                            ))}
+                        </Suspense>
+                        <button className="submit-changes-btn" onClick={onSubmitInterests}>Submit changes</button>
+                    </>
+                    :
+                    <p>"You haven't selected any interests yet! Select some to get group recommendations."</p>
+                }
+                
             </div>
             
         </>

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -82,6 +82,18 @@ const InterestList = () => {
 
     //this will update the selected interests in the database
     const submitSelectedInterests = () => {
+        const updatedInterests = {
+            chosenInterests: Array.from(userInterests.entries()).map(([key, value]) => {
+                return {id: key}
+            })
+        }
+        
+        try {
+            APIUtils.updateUserInterests(updatedInterests);
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
         
     }
 

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -81,7 +81,7 @@ const InterestList = () => {
     }
 
     //this will update the selected interests in the database
-    const submitSelectedInterests = () => {
+    const submitSelectedInterests = async () => {
         const updatedInterests = {
             chosenInterests: Array.from(userInterests.entries()).map(([key, value]) => {
                 return {id: key}
@@ -89,7 +89,8 @@ const InterestList = () => {
         }
         
         try {
-            APIUtils.updateUserInterests(updatedInterests);
+            await APIUtils.updateUserInterests(updatedInterests);
+            await APIUtils.getNewGroupRecs();
         } catch (error) {
             console.log("Status ", error.status);
             console.log("Error: ", error.message);

--- a/client/src/pages/InterestList.jsx
+++ b/client/src/pages/InterestList.jsx
@@ -46,9 +46,6 @@ const InterestList = () => {
                     apiResultData.map(interest => [interest.id, interest.title])
                 );
                 setUserInterests(initialUserInterests);
-            } else {
-                alert("Could not load user interests"); // TODO: will have better visual display for this later
-                // TODO: also need to handle message for no previously selected interests
             }
         } catch (error) {
             console.log("Status ", error.status);
@@ -91,6 +88,7 @@ const InterestList = () => {
         try {
             await APIUtils.updateUserInterests(updatedInterests);
             await APIUtils.getNewGroupRecs();
+            alert("New group recs! See Groups tab"); // TODO: Will have better visual display for this later
         } catch (error) {
             console.log("Status ", error.status);
             console.log("Error: ", error.message);

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -171,4 +171,21 @@ export default class APIUtils {
             throw {status: response.status, message: data.error};
         }
     }
+
+    static updateUserInterests = async (newInterests) => {
+        const response = await fetch('http://localhost:3000/user/interests', {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(newInterests),
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
 }

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -188,4 +188,21 @@ export default class APIUtils {
             throw {status: response.status, message: data.error};
         }
     }
+
+    //this will be called after the above method so that new groups are retrieved for user when their interests change
+    static getNewGroupRecs = async () => {
+         const response = await fetch('http://localhost:3000/user/groups/new', {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
 }

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -18,10 +18,8 @@ const interests = [
 const groups = [
     {title: 'Group 1', description: 'group 1 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 10}, {"id": 6}, {"id": 11}]},
     {title: 'Group 2', description: 'group 2 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 8}, {"id": 7}, {"id": 1}]},
-    {title: 'Group 3', description: 'group 3 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 5}, {"id": 10}, {"id": 0}]},
+    {title: 'Group 3', description: 'group 3 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 5}, {"id": 10}]},
     {title: 'Group Far away', description: 'far away from mpk', is_full: false, latitude: 35.6895, longitude: 139.6917, interests: [{"id": 10}, {"id": 2}, {"id": 7}]},
-    {title: 'Group No related interests', description: 'group not related in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 4}]},
-
 ];
 
 const events = [

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -35,7 +35,7 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
         const updatedUser = await prisma.user.findUnique({
             where: { id: req.session.userId },
             select: { id: true, interests: true }
-        });;
+        });
         //Call GroupFindAlgo, will return all suggested groups sorted by compatibility
         const suggestedGroups = await findGroups(updatedUser); //NOTE: the interests attribute part of the returned objects won't be entirely accurate - not needed for now though
 
@@ -58,7 +58,7 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
                         group: { connect: { id: group.id } },
                         user: { connect: { id: req.session.userId } },
                         status: Status.PENDING,
-                        compatibilityRatio: group.compatibilityRatio
+                        compatibilityRatio: group.compatibilityRatio.toFixed(2)
                     }
                 })
             }

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -42,7 +42,7 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
         //if no matching groups were found, create new group with just the user
         if (suggestedGroups.length === 0) {
 
-            const userCoords = getUserCoordinates(req.session.userId);
+            const userCoords = await getUserCoordinates(req.session.userId);
 
             const newGroupRecordId = await prisma.$queryRaw`INSERT INTO "Group" (title, description, is_full, coord) VALUES('temp title', 'temp description', false, ST_SetSRID(ST_MakePoint(${userCoords.longitude}, ${userCoords.latitude}), 4326)::geography) RETURNING id`;
 

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -20,7 +20,7 @@ const findGroups = async (userData) => {
     
     //for each of the possible groups, calculate the jaccard similarity to user's interests
     for (let i = 0; i < candidateGroups.length; i++) {
-        const compatibilityRatio = calcJaccardSimilarity(candidateGroups[i], expandedUserInterests.length).toFixed(2);
+        const compatibilityRatio = calcJaccardSimilarity(candidateGroups[i], expandedUserInterests.length)
         candidateGroups[i] = {...candidateGroups[i], compatibilityRatio: compatibilityRatio}
     }
 

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -1,9 +1,7 @@
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { getExpandedInterests } = require('./Utils');
-const { filterGroupsByLocation } = require('./Utils');
-
+const { getExpandedInterests, getUserCoordinates, filterGroupsByLocation } = require('./Utils');
 
 const findGroups = async (userData) => {
 
@@ -21,7 +19,7 @@ const findGroups = async (userData) => {
     //for each of the possible groups, calculate the jaccard similarity to user's interests
     for (let i = 0; i < candidateGroups.length; i++) {
         const compatibilityRatio = calcJaccardSimilarity(candidateGroups[i], expandedUserInterests.length)
-        candidateGroups[i] = {...candidateGroups[i], compatibilityRatio: compatibilityRatio}
+        candidateGroups[i] = {...candidateGroups[i], compatibilityRatio: compatibilityRatio.toFixed(2)}
     }
 
     //sort groups by most compatible to least compatible
@@ -85,20 +83,6 @@ const getCandidateGroups =  async (allGroupsNearby, allUserInterests) => {
     return groupCandidates;
     
 }
-
-
-const getUserCoordinates = async (userId) => {
-    const userCoord = await prisma.$queryRaw`
-    SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
-    FROM "User" 
-    WHERE id = ${userId}`;
-    
-    return {
-        longitude: userCoord.at(0).st_x,
-        latitude: userCoord.at(0).st_y,
-    };
-}
-
 
 module.exports = { findGroups };
 

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -12,6 +12,18 @@ const Status = Object.freeze({
     DROPPED: "DROPPED"
 });
 
+const getUserCoordinates = async (userId) => {
+    const userCoord = await prisma.$queryRaw`
+    SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
+    FROM "User" 
+    WHERE id = ${userId}`;
+    
+    return {
+        longitude: userCoord.at(0).st_x,
+        latitude: userCoord.at(0).st_y,
+    };
+}
+
 const getExpandedInterests = async (originalInterests, isGroup) => {
     let expandedInterestSet = [];
 
@@ -80,4 +92,4 @@ const filterGroupsByLocation = async (eventCoordinates, forEventSearch) => {
 
 
 
-module.exports = { Status, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation };
+module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation };


### PR DESCRIPTION
## Description

**Done in this PR**
Now when user submits their interest selection, they get an alert that new group invites are available. They can then navigate to the groups page and see group recs based on their location and interests. This is triggered every time the user updates their interests.

I also made it so that if there are absolutely no groups with related interests and in the same area as a user, they automatically create a new group themselves with their location and interests. In reality, this would be a rare scenario, but this is necessary for when I navigate away from seeded groups.

**Done in upcoming PRs**
-Continue to implement frontend feedback
-Move onto TC 2
-Set up event search triggering
-Find way I want to have groups named


## Milestones
User can get new group recommendations corresponding with their change in interests

## Resources
https://www.w3schools.com/sql/sql_insert.asp

## Test Plan
Selecting interests where there are groups:
https://www.loom.com/share/aadbd16b73014bce9efc23f2ab749eb9

Selecting an interest with no related groups around - creates new group:
 https://www.loom.com/share/6c65dcf7d1d64365a10ee083a2f57002
