### PR TITLE
Connected User Profile table in User sign up FE and BE. Implemented feedback.

### DIFF
--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -42,10 +42,10 @@ const Group = ( {groupData, updateGroup}) => {
                 <h4 className="title">{title}</h4>
             </section>
             <p>{description}</p>
-            {(groupData.status !== Status.ACCEPTED && groupData.status !== Status.DROPPED && groupData.status !== Status.REJECTED)&&
+            {(groupData.status !== Status.ACCEPTED && groupData.status !== Status.DROPPED && groupData.status !== Status.REJECTED) &&
                 <section className="compatibility-display">
                     <h5>Compatibility Ratio: </h5>
-                    <p>{compatibilityRatio * 100}%</p>
+                    <p>{Math.round(compatibilityRatio * 100)}%</p>
                 </section>
             }
         </div>

--- a/client/src/components/StatusForm.jsx
+++ b/client/src/components/StatusForm.jsx
@@ -22,9 +22,9 @@ const StatusForm = ({ onSubmitChange, currStatus }) => {
     //need to change button options depending on whether the group has already been accepted or not
     return (
         <section className="change-status-form">
-            {currStatus === Status.PENDING?<p>You haven't responded to this invite yet.</p> : <p>Click "Drop" if you would like to drop this group.</p> }
-            {currStatus === Status.PENDING&&<button onClick={() => changeSelectedState(Status.ACCEPTED)}>Accept</button>}
-            {currStatus === Status.PENDING?<button onClick={() => changeSelectedState(Status.REJECTED)}>Ignore</button>:<button onClick={() => changeSelectedState(Status.DROPPED)}>Drop</button>}
+            {currStatus === Status.PENDING ? <p>You haven't responded to this invite yet.</p> : <p>Click "Drop" if you would like to drop this group.</p> }
+            {currStatus === Status.PENDING && <button onClick={() => changeSelectedState(Status.ACCEPTED)}>Accept</button>}
+            {currStatus === Status.PENDING ? <button onClick={() => changeSelectedState(Status.REJECTED)}>Ignore</button> : <button onClick={() => changeSelectedState(Status.DROPPED)}>Drop</button>}
             <button onClick={handleSubmit} disabled={isSubmitDisabled}>Submit Changes</button>  
         </section>
     )

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -29,7 +29,7 @@ const EventsList = () => {
         try {
             const apiResultData = await APIUtils.fetchEvents();
             const mappedEvents = new Map(
-                apiResultData.events.map(event => [event.event_id, event])
+                apiResultData.events.map(event => [event.eventId, event])
             );
             setEvents(mappedEvents);
         } catch (error) {
@@ -50,7 +50,7 @@ const EventsList = () => {
                         eventData={value}
                         updateEvent= {(newEventObj) => {
                             const updatedEvents = new Map(events);
-                            updatedEvents.set(newEventObj.event_id, newEventObj);
+                            updatedEvents.set(newEventObj.eventId, newEventObj);
                             setEvents(updatedEvents);
                         }}
                     />

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -28,7 +28,7 @@ const GroupsList = () => {
         try {
             const apiResultData = await APIUtils.fetchGroups();
             const mappedGroups = new Map(
-                apiResultData.map(group => [group.group_id, group])
+                apiResultData.map(group => [group.groupId, group])
             );
             setGroups(mappedGroups);
         } catch (error) {

--- a/client/src/pages/SignUpPage.jsx
+++ b/client/src/pages/SignUpPage.jsx
@@ -48,6 +48,7 @@ const SignUpPage = () => {
                     <h1 className="title-text">Sign Up</h1>
                 </div>
 
+{/* combine these into a component or use map? */}
                 <div className="input-side">
                     <form onSubmit={handleFormSubmit}>
                         <input 

--- a/client/src/pages/SignUpPage.jsx
+++ b/client/src/pages/SignUpPage.jsx
@@ -10,7 +10,7 @@ import "../styles/SignUpPage.css"
 const SignUpPage = () => {
     const { setUser } = useUser();
 
-    const [formData, setFormData] = useState({address: DEFAULT_FORM_VALUE.address, username: DEFAULT_FORM_VALUE.username, password: DEFAULT_FORM_VALUE.password,  email: DEFAULT_FORM_VALUE.email});
+    const [formData, setFormData] = useState({firstName: DEFAULT_FORM_VALUE.firstName, lastName: DEFAULT_FORM_VALUE.lastName, address: DEFAULT_FORM_VALUE.address, username: DEFAULT_FORM_VALUE.username, password: DEFAULT_FORM_VALUE.password,  email: DEFAULT_FORM_VALUE.email});
 
     const navigate = useNavigate();
 
@@ -50,11 +50,20 @@ const SignUpPage = () => {
 
                 <div className="input-side">
                     <form onSubmit={handleFormSubmit}>
-
-                        <input placeholder="First Name"></input><br />
-                        <input placeholder="Last Name"></input><br />
-
-                        {/* Handle just these for now  - use enums for 'name'??*/}
+                        <input 
+                            placeholder="First Name"
+                            type="text"
+                            name="firstName"
+                            value={formData.firstName}
+                            onChange={handleInputChange}
+                        ></input><br />
+                        <input 
+                            placeholder="Last Name"
+                            type="text"
+                            name="lastName"
+                            value={formData.lastName}
+                            onChange={handleInputChange}
+                        ></input><br />
                         <input 
                             placeholder="Address"
                             type="text"

--- a/client/src/pages/SignUpPage.jsx
+++ b/client/src/pages/SignUpPage.jsx
@@ -48,7 +48,7 @@ const SignUpPage = () => {
                     <h1 className="title-text">Sign Up</h1>
                 </div>
 
-{/* combine these into a component or use map? */}
+{/* combine these into a component and use map? */}
                 <div className="input-side">
                     <form onSubmit={handleFormSubmit}>
                         <input 

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -16,8 +16,8 @@ const Status = Object.freeze({
 
 //const form value defaults used in login and sign up
 const DEFAULT_FORM_VALUE = {
-    first_name: "",
-    last_name: "",
+    firstName: "",
+    lastName: "",
     address: "",
     username: "",
     password: "",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,9 +22,8 @@ model User {
 
 model User_Profile {
   id         Int    @id @default(autoincrement())
-  first_name String
-  last_name  String
-  zip_code   String @db.VarChar(5)
+  firstName String
+  lastName  String
   user_id    Int    @unique
   user       User   @relation(fields: [user_id], references: [id])
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -16,16 +16,16 @@ model User {
   address      String
   events       Event_User[]
   groups       Group_User[]
-  user_profile User_Profile?
+  userProfile  User_Profile?
   interests    Interest[]
 }
 
 model User_Profile {
   id         Int    @id @default(autoincrement())
-  firstName String
-  lastName  String
-  user_id    Int    @unique
-  user       User   @relation(fields: [user_id], references: [id])
+  firstName  String
+  lastName   String
+  userId     Int    @unique
+  user       User   @relation(fields: [userId], references: [id])
 }
 
 model Event {
@@ -33,8 +33,8 @@ model Event {
   title       String
   description String
   dateTime    DateTime
-  interest_id Int?
-  interest    Interest?     @relation(fields: [interest_id], references: [id])
+  interestId  Int?
+  interest    Interest?     @relation(fields: [interestId], references: [id])
   attendees   Event_User[]
   groups      Group_Event[]
 }
@@ -43,7 +43,7 @@ model Group {
   id          Int           @id @default(autoincrement())
   title       String
   description String
-  is_full     Boolean       @default(false)
+  isFull      Boolean       @default(false)
   events      Group_Event[]
   members     Group_User[]
   interests   Group_Interest[]
@@ -52,54 +52,54 @@ model Group {
 model Interest {
   id        Int        @id @default(autoincrement())
   title     String
-  parent_id Int?
+  parentId  Int?
   level     Int
   path      String
-  parent    Interest?  @relation("InterestsSubInterests", fields: [parent_id], references: [id])
+  parent    Interest?  @relation("InterestsSubInterests", fields: [parentId], references: [id])
   children  Interest[] @relation("InterestsSubInterests")
 
-  users    User[]
-  groups   Group_Interest[]
-  events   Event[]
+  users     User[]
+  groups    Group_Interest[]
+  events    Event[]
 }
 
 model Event_User {
-  user_id  Int
-  event_id Int
+  userId   Int
+  eventId  Int
   status   Status @default(PENDING)
-  event    Event  @relation(fields: [event_id], references: [id])
-  user     User   @relation(fields: [user_id], references: [id])
+  event    Event  @relation(fields: [eventId], references: [id])
+  user     User   @relation(fields: [userId], references: [id])
 
-  @@id([user_id, event_id])
+  @@id([userId, eventId])
 }
 
 model Group_User {
-  user_id             Int
-  group_id            Int
+  userId              Int
+  groupId             Int
   status              Status @default(PENDING)
   compatibilityRatio  Decimal @default("0.00")
-  group    Group      @relation(fields: [group_id], references: [id])
-  user     User       @relation(fields: [user_id], references: [id])
+  group               Group      @relation(fields: [groupId], references: [id])
+  user                User       @relation(fields: [userId], references: [id])
 
-  @@id([user_id, group_id])
+  @@id([userId, groupId])
 }
 
 model Group_Event {
-  group_id Int
-  event_id Int
-  event    Event @relation(fields: [event_id], references: [id])
-  group    Group @relation(fields: [group_id], references: [id])
+  groupId  Int
+  eventId  Int
+  event    Event @relation(fields: [eventId], references: [id])
+  group    Group @relation(fields: [groupId], references: [id])
 
-  @@id([group_id, event_id])
+  @@id([groupId, eventId])
 }
 
 model Group_Interest {
-  group_id    Int
-  interest_id Int
-  interest    Interest @relation(fields: [interest_id], references: [id])
-  group       Group @relation(fields: [group_id], references: [id])
+  groupId     Int
+  interestId  Int
+  interest    Interest @relation(fields: [interestId], references: [id])
+  group       Group @relation(fields: [groupId], references: [id])
 
-  @@id([group_id, interest_id])
+  @@id([groupId, interestId])
 }
 
 /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -2,24 +2,24 @@ const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
 const interests = [
-    {id: 0, title: 'Music', parent_id: null, level: 1, path: "0"},
-    {id: 1, title: 'Sports',  parent_id: null, level: 1, path: "1"},
-    {id: 2, title: 'Cooking',  parent_id: null, level: 1, path: "2"},
-    {id: 3, title: 'Singing',  parent_id: 0, level: 2, path: "0.3"},
-    {id: 4, title: 'Karaoke',  parent_id: 3, level: 3, path: "0.3.4"},
-    {id: 5, title: 'Basketball',  parent_id: 1, level: 2, path: "1.5"},
-    {id: 6, title: 'Rock',  parent_id: 0, level: 2, path: "0.6"},
-    {id: 7, title: 'Indie Rock',  parent_id: 6, level: 3, path: "0.6.7"},
-    {id: 8, title: 'Hard Rock',  parent_id: 6, level: 3, path: "0.6.8"},
-    {id: 9, title: 'ACDC',  parent_id: 8, level: 4, path: "0.6.8.9"},
-    {id: 10, title: 'Tennis',  parent_id: 1, level: 2, path: "1.10"},
-    {id: 11, title: 'Baking',  parent_id: 2, level: 2, path: "2.11"},
+    {id: 0, title: 'Music', parentId: null, level: 1, path: "0"},
+    {id: 1, title: 'Sports',  parentId: null, level: 1, path: "1"},
+    {id: 2, title: 'Cooking',  parentId: null, level: 1, path: "2"},
+    {id: 3, title: 'Singing',  parentId: 0, level: 2, path: "0.3"},
+    {id: 4, title: 'Karaoke',  parentId: 3, level: 3, path: "0.3.4"},
+    {id: 5, title: 'Basketball',  parentId: 1, level: 2, path: "1.5"},
+    {id: 6, title: 'Rock',  parentId: 0, level: 2, path: "0.6"},
+    {id: 7, title: 'Indie Rock',  parentId: 6, level: 3, path: "0.6.7"},
+    {id: 8, title: 'Hard Rock',  parentId: 6, level: 3, path: "0.6.8"},
+    {id: 9, title: 'ACDC',  parentId: 8, level: 4, path: "0.6.8.9"},
+    {id: 10, title: 'Tennis',  parentId: 1, level: 2, path: "1.10"},
+    {id: 11, title: 'Baking',  parentId: 2, level: 2, path: "2.11"},
 ];
 const groups = [
-    {title: 'Group 1', description: 'group 1 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 10}, {"id": 6}, {"id": 11}]},
-    {title: 'Group 2', description: 'group 2 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 8}, {"id": 7}, {"id": 1}]},
-    {title: 'Group 3', description: 'group 3 in mpk', is_full: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 5}, {"id": 10}]},
-    {title: 'Group Far away', description: 'far away from mpk', is_full: false, latitude: 35.6895, longitude: 139.6917, interests: [{"id": 10}, {"id": 2}, {"id": 7}]},
+    {title: 'Group 1', description: 'group 1 in mpk', isFull: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 10}, {"id": 6}, {"id": 11}]},
+    {title: 'Group 2', description: 'group 2 in mpk', isFull: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 8}, {"id": 7}, {"id": 1}]},
+    {title: 'Group 3', description: 'group 3 in mpk', isFull: false, latitude: 37.4855, longitude: -122.1500, interests: [{"id": 5}, {"id": 10}]},
+    {title: 'Group Far away', description: 'far away from mpk', isFull: false, latitude: 35.6895, longitude: 139.6917, interests: [{"id": 10}, {"id": 2}, {"id": 7}]},
 ];
 
 const events = [
@@ -47,7 +47,7 @@ async function main() {
     }
     
     for (const group of groups) {
-        const groupRecordId = await prisma.$queryRaw`INSERT INTO "Group" (title, description, is_full, coord) VALUES(${group.title}, ${group.description}, ${group.is_full}, ST_SetSRID(ST_MakePoint(${group.longitude}, ${group.latitude}), 4326)::geography) RETURNING id`;
+        const groupRecordId = await prisma.$queryRaw`INSERT INTO "Group" (title, description, "isFull", coord) VALUES(${group.title}, ${group.description}, ${group.isFull}, ST_SetSRID(ST_MakePoint(${group.longitude}, ${group.latitude}), 4326)::geography) RETURNING id`;
 
         //for seeding, include interests 
         await prisma.group.update({

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -16,11 +16,11 @@ const saltRounds = 10;
 
 //Signup route
 router.post('/signup', async (req, res) => {
-    const { address, username, email, password } = req.body;
+    const { address, username, email, password, firstName, lastName } = req.body;
 
     try {
-        if (!username || !email || !password) {
-            return res.status(400).json({ error: "Username, email, and password are required." });
+        if (!username || !email || !password || !firstName || !lastName) {
+            return res.status(400).json({ error: "First name, last name, username, email, and password are required." });
         }
 
         if (password.length < 8) {
@@ -56,6 +56,13 @@ router.post('/signup', async (req, res) => {
         // Store user ID and username in the session, allowing them to remain authenticated as they navigate the website
         req.session.userId = newUser.id
         req.session.username = newUser.username
+
+        //connect to a new user profile as well
+        await prisma.user.update({
+            where: {id: req.session.userId},
+            data: {user_profile: { create: {firstName: firstName, lastName: lastName}}}
+        })
+
         res.status(201).json({ message: "Sign up successful!", id: newUser.id, username: newUser.username }) 
 
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -60,7 +60,7 @@ router.post('/signup', async (req, res) => {
         //connect to a new user profile as well
         await prisma.user.update({
             where: {id: req.session.userId},
-            data: {user_profile: { create: {firstName: firstName, lastName: lastName}}}
+            data: {userProfile: { create: {firstName: firstName, lastName: lastName}}}
         })
 
         res.status(201).json({ message: "Sign up successful!", id: newUser.id, username: newUser.username }) 

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -22,7 +22,7 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
                         event: {
                             include: {
                                 attendees:{
-                                    where: {NOT: {user_id: req.session.userId}},
+                                    where: {NOT: {userId: req.session.userId}},
                                     include: {
                                         user: {include: {groups: true}}
                                     },
@@ -36,7 +36,7 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
                                                 members: {
                                                     some: {
                                                         AND: [
-                                                            {user_id: req.session.userId}, 
+                                                            {userId: req.session.userId}, 
                                                             {status: Status.ACCEPTED}
                                                         ]   
                                                     }
@@ -59,16 +59,16 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
 })
 
 //update user's status for an event
-router.patch('/user/events/:event_id/status', isAuthenticated, async (req, res) => {
-    const event_id = parseInt(req.params.event_id);
+router.patch('/user/events/:eventId/status', isAuthenticated, async (req, res) => {
+    const eventId = parseInt(req.params.eventId);
     const {updatedStatus} = req.body; 
 
     try {
         const event_user = await prisma.event_User.findUnique({
                 where: {
-                    user_id_event_id: {
-                        user_id: req.session.userId,
-                        event_id: event_id
+                    userId_eventId: {
+                        userId: req.session.userId,
+                        eventId: eventId
                     }
                 }
         });
@@ -79,9 +79,9 @@ router.patch('/user/events/:event_id/status', isAuthenticated, async (req, res) 
 
         const updatedEvent = await prisma.event_User.update({
             where: {
-                user_id_event_id: {
-                    user_id: req.session.userId,
-                    event_id: event_id
+                userId_eventId: {
+                    userId: req.session.userId,
+                    eventId: eventId
                 }
             },
             data: {

--- a/server/routes/interests.js
+++ b/server/routes/interests.js
@@ -12,7 +12,7 @@ router.get('/interests', isAuthenticated, async (req, res) => {
     try {
         const parentInterests = await prisma.interest.findMany({
             where: {
-                parent_id: null, 
+                parentId: null, 
             },
             include: { 
                 children: true

--- a/server/systems/EventFindAlgo.js
+++ b/server/systems/EventFindAlgo.js
@@ -17,7 +17,7 @@ const scheduleEventsForGroups = async () => {
         const groupsNearby = await filterGroupsByLocation(eventCoords, true);
 
         //for these groups, additionally filter by ones that include this event's interest in their array of interests AND haven't been sent this event invite yet
-        const candidateGroups = await getCandidateGroups(groupsNearby, retrievedEvent.interest_id, retrievedEvent.id);
+        const candidateGroups = await getCandidateGroups(groupsNearby, retrievedEvent.interestId, retrievedEvent.id);
         for (group of candidateGroups) {
             const inviteStatus = sendInvitesToUsers();
             if (inviteStatus === 200) {
@@ -71,12 +71,12 @@ const getCandidateGroups = async (allGroupsNearby, eventInterest, eventId) => {
             id: { in: groupIds },
             interests: {
                 some: {
-                    interest_id: eventInterest
+                    interestId: eventInterest
                 }
             },
             events: {
                 none: {
-                    event_id: eventId,
+                    eventId: eventId,
                 },
             }
         },
@@ -106,7 +106,7 @@ const getAllEvents = async () => {
 
     //return upcoming events - should be what's left
     return await prisma.$queryRaw`
-   SELECT ST_X(coord::geometry), ST_Y(coord::geometry), "id", "title", "description", "dateTime", "interest_id" FROM "Event"`;
+   SELECT ST_X(coord::geometry), ST_Y(coord::geometry), "id", "title", "description", "dateTime", "interestId" FROM "Event"`;
 
 
 }

--- a/server/systems/GroupFindAlgo.js
+++ b/server/systems/GroupFindAlgo.js
@@ -53,7 +53,7 @@ const getCandidateGroups =  async (allGroupsNearby, allUserInterests) => {
             id: { in: groupIds },
             interests: {
                 some: {
-                    interest_id: {in: interestIds}
+                    interestId: {in: interestIds}
                 }
             },
         },

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -31,7 +31,7 @@ const getExpandedInterests = async (originalInterests, isGroup) => {
         let currInterest = interest;
         if (isGroup) currInterest = interest.interest;
 
-        if (currInterest.parent_id == null) {
+        if (currInterest.parentId == null) {
             expandedInterestSet.push(currInterest);
             continue;
         }
@@ -86,7 +86,7 @@ const filterGroupsByLocation = async (eventCoordinates, forEventSearch) => {
     } 
 
     //if it is for group search for users to join, we do need to exclude full groups
-    return await prisma.$queryRaw`SELECT id, title FROM "Group" WHERE ST_DWithin(coord, ST_SetSRID(ST_MakePoint(${eventCoordinates.longitude}, ${eventCoordinates.latitude}), 4326)::geography, ${LOCATION_SEARCH_RADIUS}) AND is_full= FALSE`;
+    return await prisma.$queryRaw`SELECT id, title FROM "Group" WHERE ST_DWithin(coord, ST_SetSRID(ST_MakePoint(${eventCoordinates.longitude}, ${eventCoordinates.latitude}), 4326)::geography, ${LOCATION_SEARCH_RADIUS}) AND "isFull"= FALSE`;
 
 }
 


### PR DESCRIPTION
## Description

**Done in this PR**
Before moving forward on TC 2, I made sure the User_Profile table is connected on user sign up and user has to enter first and last name on sign up. Now when a User entry is created, a corresponding User_Profile entry is created.

Since I was already making DB changes, I also implemented previous feedback on maintaining consistent casing for naming. It looks like there are a lot of changes but most are just converting from snake case to camel case. I also implemented more feedback received today.

**Done in upcoming PRs**
-Start on TC 2 with a basic user search flow without caching
-Continue to implement frontend feedback

## Milestones
-User can search for other users, typing in their username or real name.

## Resources

## Test Plan
Now, when you try to sign up without typing first and last name, it doesn't allow it. Also, the database now stores one-to-one relationship between User table and User_Profile table for new users
