### PR TITLE
ServerSide cache structure set up - BE changes

### DIFF
--- a/server/data_structures/DoublyLinkedList.js
+++ b/server/data_structures/DoublyLinkedList.js
@@ -1,0 +1,69 @@
+class DoublyLinkedList {
+
+    constructor() {
+        this.head = null;
+        this.tail = null;
+        this.length = 0;
+    }
+
+    getLength() {
+        return this.length;
+    }
+    
+    //beginning(head) will be considered most recent
+    insertBeginning(key, value) {
+        const newNode = new Node(key, value);
+        if (this.length === 0) {
+            this.head = newNode;
+            this.tail = newNode;
+        } else {
+            newNode.prev = this.head;
+            this.head.next = newNode;
+            this.head = newNode;
+        }
+        this.length++;
+
+        return newNode;
+    }
+
+    //end(tail) will be considered least recent
+    removeEnd() {
+        let tempTail = this.tail;
+        if (this.length === 0) {
+            return null;
+        }
+        if (this.length == 1) {
+            this.head = null;
+            this.tail = null;
+        } else {
+            this.tail = this.tail.next;
+            this.tail.prev = null;
+            tempTail.next = null;
+        }
+        this.length--;
+        return tempTail;   
+    }
+
+    //used in debugging to see contents of DLL
+    getList() {
+        let dllArr = [];
+        let currNode = this.head;
+        while(currNode != null) {
+            dllArr.push({key: currNode.key,value: currNode.value})
+            currNode = currNode.prev;
+        }
+        return dllArr;
+    }
+}
+
+class Node {
+    constructor(key, value) {
+        this.key = key;
+        this.value = value;
+        this.next = null;
+        this.prev = null;
+    }
+}
+
+
+module.exports = {DoublyLinkedList};

--- a/server/data_structures/LRUCache.js
+++ b/server/data_structures/LRUCache.js
@@ -1,0 +1,41 @@
+const { DoublyLinkedList } = require("./DoublyLinkedList");
+
+//cache structure with Map and DLL. 
+class LRUCache {
+    constructor(maxCacheSize) {
+        this.DLL = new DoublyLinkedList()
+        this.HashMap = new Map();
+        this.MAX_CACHE_SIZE = maxCacheSize
+    }
+
+    checkIsFull() {
+        if (this.DLL.getLength() === this.MAX_CACHE_SIZE) {
+            return true
+        }
+        return false
+    }
+
+    addEntry(newKey, newValue) {
+        if(this.checkIsFull()) {
+            const removedNode = this.DLL.removeEnd(); //if full remove least recently used node
+            this.HashMap.delete(removedNode.key);
+        }
+
+        const addedNode = this.DLL.insertBeginning(newKey, newValue); //insert at beginning because most recently used
+        this.HashMap.set(addedNode.key, addedNode)
+    }
+
+    getEntry(queriedKey) {
+        if(this.HashMap.has(queriedKey)) return this.HashMap.get(queriedKey).value;
+        return null;
+    }
+
+    //for debugging
+    printCache(message) {
+        console.log(message)
+        console.log("DLL: ",this.DLL.getList())
+        console.log("Map: ",this.HashMap)
+    }
+}
+
+module.exports = {LRUCache};

--- a/server/systems/ServerSideUserResultsCache.js
+++ b/server/systems/ServerSideUserResultsCache.js
@@ -1,0 +1,38 @@
+const { LRUCache } = require("../data_structures/LRUCache");
+
+const MAX_LOWER_LEVEL_CACHE_SIZE = 100;
+const MAX_UPPER_LEVEL_CACHE_SIZE = 50;
+
+class ServerSideCache {
+    //this will be a leveled cache 
+    //lower level (i.e globalUserCache) will have general keyword and user search results
+    //upper level (i.e userSpecificCache) will have user search results sorted by closest user relation with user-specific keys
+    constructor() {
+        this.globalUserCache = new LRUCache(MAX_LOWER_LEVEL_CACHE_SIZE); 
+        this.userSpecificCache = new LRUCache(MAX_UPPER_LEVEL_CACHE_SIZE);
+    }
+
+    checkUserSpecificCache(queriedKey) {
+        return this.userSpecificCache.getEntry(queriedKey);
+    }
+
+    checkGlobalUserCache(queriedKey) {
+        return this.globalUserCache.getEntry(queriedKey);
+    }
+
+    insertUserSpecificCache(newKey, newValue) {
+        this.userSpecificCache.addEntry(newKey, newValue);
+    }
+
+    insertGlobalUserCache(newKey, newValue) {
+        this.globalUserCache.addEntry(newKey, newValue);
+    }
+
+    //for debugging
+    printCaches() {
+        this.globalUserCache.printCache("Global cache: ");
+        this.userSpecificCache.printCache("User specific cache: ");
+    }
+}
+
+module.exports = {ServerSideCache}


### PR DESCRIPTION
## Description

**Done in this PR**
Created DoublyLinkedList data structure that can be used in LRU cache structure. I also created the LRU cache data structure itself with the necessary methods to update both the internal DLL and Map. Lastly, I created a ServerSideCache class that has two internal caches, global level and user-specific level.

Overall, this sets up my server-side cache.

**Tradeoffs and complexity considerations**
When a user searches, they should be shown all users that match AND are prioritized by being in the same groups first. By having a two-leveled cache, the lower level can store general search queries and user results, and then an entry in the higher level cache can sort data from the corresponding lower level cache entry by proximity in group membership. This data is more likely valuable to the user and can now be accessed quicker.

**Done in upcoming PRs**
-Integrate server side caching into existing search endpoint
-Work on caching for autocomplete feature

## Milestones
-User can search for other users with a user-friendly search system, geared toward prioritizing more likely search queries.

## Resources
https://www.interviewcake.com/concept/java/lru-cache
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
https://www.geeksforgeeks.org/javascript/javascript-classes/
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get

## Test Plan
For testing, I tried adding data to the global cache and limited size to 2.

Adding in this order: 'test key', 'test key2':

<img width="340" height="412" alt="Screenshot 2025-07-14 at 6 46 24 PM" src="https://github.com/user-attachments/assets/fdae774a-0d30-40d3-bb65-706b8b785968" />

Adding 'test key3':

<img width="365" height="409" alt="Screenshot 2025-07-14 at 6 47 12 PM" src="https://github.com/user-attachments/assets/1f3cd76a-17bb-4a69-80e0-b594a9e44a0b" />

