### PR TITLE
Lower level cache now integrated with search endpoint (BE changes) and continued feedback implementation (FE changes)

### DIFF
--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -42,7 +42,7 @@ const Group = ( {groupData, updateGroup}) => {
                 <h4 className="title">{title}</h4>
             </section>
             <p>{description}</p>
-            {(groupData.status !== Status.ACCEPTED && groupData.status !== Status.DROPPED && groupData.status !== Status.REJECTED) &&
+            {(groupData.status === Status.PENDING) &&
                 <section className="compatibility-display">
                     <h5>Compatibility Ratio: </h5>
                     <p>{Math.round(compatibilityRatio * 100)}%</p>

--- a/client/src/components/StatusForm.jsx
+++ b/client/src/components/StatusForm.jsx
@@ -22,9 +22,18 @@ const StatusForm = ({ onSubmitChange, currStatus }) => {
     //need to change button options depending on whether the group has already been accepted or not
     return (
         <section className="change-status-form">
-            {currStatus === Status.PENDING ? <p>You haven't responded to this invite yet.</p> : <p>Click "Drop" if you would like to drop this group.</p> }
-            {currStatus === Status.PENDING && <button onClick={() => changeSelectedState(Status.ACCEPTED)}>Accept</button>}
-            {currStatus === Status.PENDING ? <button onClick={() => changeSelectedState(Status.REJECTED)}>Ignore</button> : <button onClick={() => changeSelectedState(Status.DROPPED)}>Drop</button>}
+            {currStatus === Status.PENDING ? 
+                <>
+                    <p>You haven't responded to this invite yet.</p> 
+                    <button onClick={() => changeSelectedState(Status.ACCEPTED)}>Accept</button> 
+                    <button onClick={() => changeSelectedState(Status.REJECTED)}>Ignore</button>
+                </>
+                : 
+                <>
+                    <p>Click "Drop" if you would like to drop this group.</p> 
+                    <button onClick={() => changeSelectedState(Status.DROPPED)}>Drop</button>
+                </>
+            }
             <button onClick={handleSubmit} disabled={isSubmitDisabled}>Submit Changes</button>  
         </section>
     )

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -45,7 +45,7 @@ const GroupsList = () => {
             <Suspense fallback={<p>Loading...</p>}>
                 {Array.from(displayedGroups.entries()).map(([key, value]) => (
                     <Group 
-                        key={key}
+                        key={value.id}
                         groupData={value}
                         updateGroup = {(newGroupObj, isGroupErased, groupId) => {
                             const updatedGroups = new Map(groups);

--- a/client/src/pages/SignUpPage.jsx
+++ b/client/src/pages/SignUpPage.jsx
@@ -10,7 +10,7 @@ import "../styles/SignUpPage.css"
 const SignUpPage = () => {
     const { setUser } = useUser();
 
-    const [formData, setFormData] = useState({firstName: DEFAULT_FORM_VALUE.firstName, lastName: DEFAULT_FORM_VALUE.lastName, address: DEFAULT_FORM_VALUE.address, username: DEFAULT_FORM_VALUE.username, password: DEFAULT_FORM_VALUE.password,  email: DEFAULT_FORM_VALUE.email});
+    const [formData, setFormData] = useState(DEFAULT_FORM_VALUE);
 
     const navigate = useNavigate();
 

--- a/server/data_structures/LRUCache.js
+++ b/server/data_structures/LRUCache.js
@@ -9,10 +9,7 @@ class LRUCache {
     }
 
     checkIsFull() {
-        if (this.DLL.getLength() === this.MAX_CACHE_SIZE) {
-            return true
-        }
-        return false
+        return this.DLL.getLength() === this.MAX_CACHE_SIZE
     }
 
     addEntry(newKey, newValue) {

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -9,7 +9,7 @@ const { findGroups } = require('../systems/GroupFindAlgo');
 const { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation, recalculateGroupInterests } = require('../systems/GroupUpdateMethods')
 const { Status, filterMembersByStatus, getUserCoordinates } = require('../systems/Utils');
 
-const FULL_GROUP_SIZE = 10;
+const FULL_GROUP_SIZE = 15;
 
 //get user's groups 
 router.get('/user/groups/', isAuthenticated, async (req, res) => {

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -4,8 +4,10 @@ const router = express.Router()
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { isAuthenticated } = require('../middleware/CheckAutheticated')
+const { isAuthenticated } = require('../middleware/CheckAutheticated');
+const { ServerSideCache } = require('../systems/ServerSideUserResultsCache');
 
+const serverSideCache = new ServerSideCache();
 
 //user search endpoint
 router.get('/search/users', isAuthenticated, async (req, res) => {
@@ -22,30 +24,52 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
     }
 
     try {
-        //find users with username, firstname, and/or last name that start with the search query passed from the frontend (make filter case insensitive)
+        const highLevelResults = serverSideCache.checkUserSpecificCache(searchQuery, req.session.userId);
+        const lowerLevelResults = serverSideCache.checkGlobalUserCache(searchQuery);
+        //---Step 1: check higher level cache---//
+        if (highLevelResults) { //cache hit
+            res.status(201).json(highLevelResults); 
 
-        //note: learned about usage of spread operator for conditional where clause in prisma from here: https://stackoverflow.com/questions/72197774/how-to-call-where-clause-conditionally-prisma
-        const userResults = await prisma.user.findMany({
-            where: {
-                    ...( lastWord ? {
-                            AND: [
-                                { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
-                                { userProfile: { lastName: { startsWith: lastWord, mode: 'insensitive' } } },
-                            ]
-                        }
-                        : 
-                        {
-                            OR: [
-                                { username: { startsWith: firstWord, mode: 'insensitive' } },
-                                { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
-                                { userProfile: { lastName: { startsWith: firstWord, mode: 'insensitive' } } },
-                            ]
-                        }
-                    )
-                },
-                select: { username: true, id: true }
+        //---Step 2: check lower level cache---//
+        } else if (lowerLevelResults) { //cache hit
+            // TODO: See step 5 below (move filtered lowerLevelResults data to higher level cache and return this to user)
+            res.status(201).json(lowerLevelResults); 
+
+        //---Step 3: cache miss, so load from database---//
+        } else {
+            //find users with username, firstname, and/or last name that start with the search query passed from the frontend (make filter case insensitive)
+            //note: learned about usage of spread operator for conditional where clause in prisma from here: https://stackoverflow.com/questions/72197774/how-to-call-where-clause-conditionally-prisma
+            const userResults = await prisma.user.findMany({
+                where: {
+                        ...( lastWord ? {
+                                AND: [
+                                    { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
+                                    { userProfile: { lastName: { startsWith: lastWord, mode: 'insensitive' } } },
+                                ]
+                            }
+                            : 
+                            {
+                                OR: [
+                                    { username: { startsWith: firstWord, mode: 'insensitive' } },
+                                    { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
+                                    { userProfile: { lastName: { startsWith: firstWord, mode: 'insensitive' } } },
+                                ]
+                            }
+                        )
+                    },
+                    select: { username: true, id: true }
             })
-        res.status(201).json(userResults)
+
+            //---Step 4: store in lower level cache---//
+            serverSideCache.insertGlobalUserCache(searchQuery, userResults);
+
+            //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
+            // TODO: filter based on user's groups
+            // TODO: sort based on users with most amount of matching groups
+
+            res.status(201).json(userResults)
+        }
+
     } catch (error) {
         console.error("Error fetching user results:", error)
         res.status(500).json({ error: "Something went wrong while searching for users." })

--- a/server/systems/ServerSideUserResultsCache.js
+++ b/server/systems/ServerSideUserResultsCache.js
@@ -12,16 +12,16 @@ class ServerSideCache {
         this.userSpecificCache = new LRUCache(MAX_UPPER_LEVEL_CACHE_SIZE);
     }
 
-    checkUserSpecificCache(queriedKey) {
-        return this.userSpecificCache.getEntry(queriedKey);
+    checkUserSpecificCache(queriedKey, userId) {
+        return this.userSpecificCache.getEntry(queriedKey + "-" + userId);
     }
 
     checkGlobalUserCache(queriedKey) {
         return this.globalUserCache.getEntry(queriedKey);
     }
 
-    insertUserSpecificCache(newKey, newValue) {
-        this.userSpecificCache.addEntry(newKey, newValue);
+    insertUserSpecificCache(newKey, newValue, userId) {
+        this.userSpecificCache.addEntry(newKey + "-" + userId, newValue);
     }
 
     insertGlobalUserCache(newKey, newValue) {


### PR DESCRIPTION
## Description

**Done in this PR**
-Integrated the lower level cache with search endpoint and clearly commented all current and upcoming steps for cache storing and cache checking (see userSearch.js and ServerSideUserResultsCache.js).

-I also implemented some feedback from PRs 33-35.

**Done in upcoming PRs**
-Finish integrating caching with the search endpoint by finishing the TODOs in comments
-Continue to implement feedback

## Milestones
-User can search for other users in an optimized way and with results tailored to them 

## Resources
-Used the below resource to get the idea for user-specific cache keys to be concatenated with '-':
https://stackoverflow.com/questions/13381731/caching-with-multiple-keys

## Test Plan
Search for 'deb' on start up. First cache miss, then cache hit:
<img width="623" height="227" alt="Screenshot 2025-07-14 at 10 20 06 PM" src="https://github.com/user-attachments/assets/339a3423-c021-4d71-bd55-fe525b49b839" />

Same when searching for 'John':
<img width="565" height="607" alt="Screenshot 2025-07-14 at 10 20 40 PM" src="https://github.com/user-attachments/assets/9c359eb9-c209-4dd9-ad59-ce000de57669" />
