### PR TITLE
Search results now use higher level cache for user-specific results - FE and BE changes

### DIFF
--- a/client/src/components/UserResultCard.jsx
+++ b/client/src/components/UserResultCard.jsx
@@ -1,12 +1,13 @@
 import { FaUserCircle } from "react-icons/fa";
 import "../styles/UserResultCard.css";
 
-const UserResultCard = ({username}) => {
+const UserResultCard = ({username, numMutualGroups}) => {
     return (
         <div className="user-card">
             {/* temporary placement for user profile picture */}
             <FaUserCircle className="user-img"/> 
-            <p>{username}</p>            
+            <p>{username}</p>
+            {numMutualGroups && <p>You guys are in {numMutualGroups} groups together</p>}            
         </div>
     )
 }

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -52,6 +52,7 @@ const SearchResultsPage = () => {
                             return <UserResultCard 
                                 key={userObj.id}
                                 username={userObj.username}
+                                numMutualGroups={userObj.numMutualGroups}
                             />
                         })}
                     </Suspense> 

--- a/server/data_structures/DoublyLinkedList.js
+++ b/server/data_structures/DoublyLinkedList.js
@@ -26,6 +26,26 @@ class DoublyLinkedList {
         return newNode;
     }
 
+    moveBeginning(node) {
+
+        const tempNodeKey = node.key
+        const tempNodeValue = node.value
+
+        if (node.prev) {
+            node.prev.next = node.next
+        }
+        if (node.next) {
+            node.next.prev = node.prev
+        }
+
+        node.next = null
+        node.prev = null
+
+        this.length--;
+
+        return this.insertBeginning(tempNodeKey, tempNodeValue);
+    }
+
     //end(tail) will be considered least recent
     removeEnd() {
         let tempTail = this.tail;

--- a/server/data_structures/LRUCache.js
+++ b/server/data_structures/LRUCache.js
@@ -23,7 +23,12 @@ class LRUCache {
     }
 
     getEntry(queriedKey) {
-        if(this.HashMap.has(queriedKey)) return this.HashMap.get(queriedKey).value;
+        if(this.HashMap.has(queriedKey)) {
+            //if already in cache, also make head of DLL because it is now the most recent query
+            //moveBeginning return new node, so replace in map as well
+            this.HashMap.set(queriedKey, this.DLL.moveBeginning(this.HashMap.get(queriedKey)))
+            return this.HashMap.get(queriedKey).value;
+        }
         return null;
     }
 

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -6,6 +6,7 @@ const prisma = new PrismaClient()
 
 const { isAuthenticated } = require('../middleware/CheckAutheticated');
 const { ServerSideCache } = require('../systems/ServerSideUserResultsCache');
+const { getOtherGroupMembers } = require('../systems/Utils');
 
 const serverSideCache = new ServerSideCache();
 
@@ -65,6 +66,7 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
 
             //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
             // TODO: filter based on user's groups
+            const groupMatesMap = await getOtherGroupMembers(req.session.userId);
             // TODO: sort based on users with most amount of matching groups
 
             res.status(201).json(userResults)

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -39,10 +39,10 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
             //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
             if (closestUsers === null) {
                 res.status(201).json(lowerLevelResults);
+            } else {
+                //return these prioritzed and specialized results to the user
+                res.status(201).json(closestUsers);
             }
-
-            //return these prioritzed and specialized results to the user
-            res.status(201).json(closestUsers);
 
         //---Step 3: cache miss, so load from database---//
         } else {


### PR DESCRIPTION
## Description

**Done in this PR**
-The higher level/user-specific cache is now used in the search endpoint. Now, when a user searches a query, the results in the global cache for that query are filtered and sorted based on users who share the same groups. This is stored in the higher level cache and returned to the user.

**Technical complexities and considerations**
-QUESTION: Regarding the getOtherGroupMembers function in server/systems/Utils.js: should I have a separate cache for the user's fellow group members, or another easier way to access it rather than a DB query? I am unsure if this additional DB query is an optimization concern.

**Done in upcoming PRs**
-Need a way to control what and how much is loaded onto the page after search. Right now if there is a match in user-specific results, that's all that's showed, so I need to decide a way for the user to be able to query more from the lower level cache.
-Need TTL or another way to refresh data in cache

## Milestones
-User can search for other users and get result tailored to them for an easier search experience

## Resources
https://www.interviewcake.com/concept/python/lru-cache?

## Test Plan
-I used my debugging cache printing methods to make sure that the right entries were stored in the cache in the right order. I also added console.log statements throughout the search endpoint to make sure data was being read from the cache rather than DB when applicable.

-Here is an image of the more tailored user search results:
<img width="1514" height="762" alt="Screenshot 2025-07-15 at 12 54 24 PM" src="https://github.com/user-attachments/assets/f4912c10-430f-4f0c-87e7-d02eba977851" />

