### PR TITLE
Now able to load more results as desired - FE and BE changes

### DIFF
--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -13,7 +13,7 @@ const SearchResultsPage = () => {
     const [isDisplayedAutocompleteSuggestions, setIsDisplayedAutocompleteSuggestions] = useState(false);
     const [autocompleteSuggestions, setAutocompleteSuggestions] = useState(new Set());
     const [isLoadMoreHidden, setIsLoadMoreHidden] = useState(false);
-    const pageMarker = useRef('HL0');
+    const pageMarker = useRef('HL0'); //'HL' means higher level cache. 'LL' means lower level cache. the number at the end of the pageMarker is the index
     const displayedAutocompleteSuggestions = useMemo(
         () => {
             if (searchQuery === "") {
@@ -80,7 +80,12 @@ const SearchResultsPage = () => {
                 if (apiResultData.results.length === 0) {
                     setNotif("No results found!")
                 } else {
-                    setSearchResults([...searchResults, ...apiResultData.results]);
+                    //handling duplicate data:
+                    const currentResultsIds = new Set(searchResults.map((currResult) => currResult.id));
+                    const filteredNewResults = apiResultData.results.filter((newResult) => {
+                        return !currentResultsIds.has(newResult.id) //having created a set makes this operation O(1)
+                    })
+                    setSearchResults([...searchResults, ...filteredNewResults]);
                 }
             } catch (error) {
                 console.log("Status ", error.status);
@@ -125,7 +130,7 @@ const SearchResultsPage = () => {
             </div>
             
             <div className="user-results-list">
-                {searchResults.length < 1 ? <p>{notif}</p> :
+                {searchResults.length < 1 ? <p className="notif-para">{notif}</p> :
                     <div className="card-container">
                         <Suspense fallback={<p>Loading...</p>}>
                             {searchResults.map((userObj) => {
@@ -138,7 +143,7 @@ const SearchResultsPage = () => {
                         </Suspense> 
                     </div>
                 }
-                {!isLoadMoreHidden && <button onClick={handleSearchSubmit}>Load More</button>}
+                {!isLoadMoreHidden && <button className="load-more-btn" onClick={handleSearchSubmit}>Load More</button>}
             </div>
         </div>
     )

--- a/client/src/styles/SearchResultsPage.css
+++ b/client/src/styles/SearchResultsPage.css
@@ -15,6 +15,7 @@
     padding: 10px;
     min-width: 300px;
     margin-top: 30px;
+    margin-left: 0;
 }
 
 .search-btn {
@@ -25,15 +26,19 @@
 .autocomplete-recommendation {
     padding: 5px;
     background-color: rgb(209, 207, 207);
-    margin: 2px 2px 2px 30px;
+    margin: 2px 2px 2px 64px;
     text-align: left;
     border-width: 2px;
     border-radius: 20px;
     max-width: 300px;
-    position: static;
 }
 
 .user-results-list {
     top: 200px;
     position: absolute;
+}
+
+.notif-para, .load-more-btn {
+    position: relative;
+    left: 45vw
 }

--- a/client/src/styles/UserResultCard.css
+++ b/client/src/styles/UserResultCard.css
@@ -1,7 +1,9 @@
 .user-card {
-    box-shadow: 0px 10px 10px rgb(114, 112, 112);  
+    box-shadow: 0px 5px 10px rgb(114, 112, 112);  
     max-height: 400px;
     padding: 50px;
+    width: 300px;
+    margin-top: 10px;
 }
 
 .user-img {

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -206,8 +206,8 @@ export default class APIUtils {
         }
     }
 
-    static userSearch = async (searchQuery) => {
-        const response = await fetch(`http://localhost:3000/search/users/?searchQuery=${searchQuery}`, {
+    static userSearch = async (searchQuery, pageMarker) => {
+        const response = await fetch(`http://localhost:3000/search/users/?searchQuery=${searchQuery}&pageMarker=${pageMarker}`, {
             method: "GET",
             headers: { "Content-Type": "application/json" },
             credentials: "include",

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -10,6 +10,7 @@ const { getOtherGroupMembers } = require('../systems/Utils');
 
 const serverSideCache = new ServerSideCache();
 
+const NUM_RESULTS_PER_CALL = 5; //TODO: change to higher number after testing
 
 router.get('/search/users/typeahead', isAuthenticated, async (req, res) => {
     const allUserSpecificSearches = serverSideCache.getUserSpecificCacheByUserId(req.session.userId);
@@ -22,7 +23,9 @@ router.get('/search/users/typeahead', isAuthenticated, async (req, res) => {
 //user search endpoint
 router.get('/search/users', isAuthenticated, async (req, res) => {
 
-    const { searchQuery } = req.query;
+    const { searchQuery, pageMarker } = req.query;
+
+    const pageIndex = parseInt(pageMarker.charAt(2));
 
     /*note: usernames should be one word, so if the search query had a space, that means the user is searching for a first and last name. If there is a second keyword, search by matching
         first AND last name, else just search for first word match with either username, firstname, or lastname */
@@ -36,22 +39,37 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
     try {
         const highLevelResults = serverSideCache.checkUserSpecificCache(searchQuery, req.session.userId);
         const lowerLevelResults = serverSideCache.checkGlobalUserCache(searchQuery);
+        
         //---Step 1: check higher level cache---//
-        if (highLevelResults) { //cache hit
-            res.status(201).json(highLevelResults); 
+        if (pageMarker === 'HL0' && highLevelResults) { //cache hit
+            res.status(201).json({results: highLevelResults, newPageMarker: 'LL0'}); 
 
         //---Step 2: check lower level cache---//
         } else if (lowerLevelResults) { //cache hit
-            //See step 5 below (move filtered lowerLevelResults data to higher level cache and return this to user)
-            const closestUsers = await makeUserSpecificEntry(lowerLevelResults, searchQuery, req.session.userId);
-
-            //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
-            if (closestUsers === null) {
-                res.status(201).json(lowerLevelResults);
+            if (pageMarker.startsWith('L')) {
+                if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) {
+                    res.status(201).json({results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}`}); 
+                } else {
+                    res.status(201).json({results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END'}); //send back end of list
+                }
+                
             } else {
-                //return these prioritzed and specialized results to the user
-                res.status(201).json(closestUsers);
+                //See step 5 below (move filtered lowerLevelResults data to higher level cache and return this to user)
+                const closestUsers = await makeUserSpecificEntry(lowerLevelResults, searchQuery, req.session.userId);
+
+                //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
+                if (closestUsers === null) {
+                    if (lowerLevelResults.length > NUM_RESULTS_PER_CALL) {
+                        res.status(201).json({results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}`}); //send back LL15 if exists
+                    } else {
+                        res.status(201).json({results: lowerLevelResults, newPageMarker: 'END' });
+                    }
+                } else {
+                    //return these prioritzed and specialized results to the user
+                    res.status(201).json({results: closestUsers, newPageMarker: 'LL0'}); //send back LL0
+                }
             }
+            
 
         //---Step 3: cache miss, so load from database---//
         } else {
@@ -81,15 +99,27 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
             //---Step 4: store in lower level cache---//
             serverSideCache.insertGlobalUserCache(searchQuery, userResults);
 
-            //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
-            const closestUsers = await makeUserSpecificEntry(userResults, searchQuery, req.session.userId); 
-
-            //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
-            if (closestUsers === null) {
-                res.status(201).json(userResults);
+            if (pageMarker.startsWith('L')) {
+                if ((userResults.length > pageIndex) && (userResults.length > pageIndex + NUM_RESULTS_PER_CALL)) {
+                    res.status(201).json({results: userResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}`}); //send back LL+15 if exists
+                } else {
+                    res.status(201).json({results: userResults.slice(pageIndex), newPageMarker: 'END'}); //send back end of list
+                }
             } else {
-                //return these prioritzed and specialized results to the user
-                res.status(201).json(closestUsers);
+                //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
+                const closestUsers = await makeUserSpecificEntry(userResults, searchQuery, req.session.userId); 
+
+                //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
+                if (closestUsers === null) {
+                    if (userResults.length > NUM_RESULTS_PER_CALL) {
+                        res.status(201).json({results: userResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}`}); //send back LL15 if exists
+                    } else {
+                        res.status(201).json({results: userResults, newPageMarker: 'END' }); 
+                    }
+                } else {
+                    //return these prioritzed and specialized results to the user
+                    res.status(201).json({results: closestUsers, newPageMarker: 'LL0'}); //send back LL0
+                }
             }
             
         }

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -39,20 +39,20 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
     try {
         const highLevelResults = serverSideCache.checkUserSpecificCache(searchQuery, req.session.userId);
         const lowerLevelResults = serverSideCache.checkGlobalUserCache(searchQuery);
-        
+
         //---Step 1: check higher level cache---//
         if (pageMarker === 'HL0' && highLevelResults) { //cache hit
-            res.status(201).json({results: highLevelResults, newPageMarker: 'LL0'}); 
+            res.status(201).json({ results: highLevelResults, newPageMarker: 'LL0' });
 
         //---Step 2: check lower level cache---//
         } else if (lowerLevelResults) { //cache hit
             if (pageMarker.startsWith('L')) {
-                if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) {
-                    res.status(201).json({results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}`}); 
+                if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) { //ensure index increment is still within array size
+                    res.status(201).json({ results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` });
                 } else {
-                    res.status(201).json({results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END'}); //send back end of list
+                    res.status(201).json({ results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END' }); //send back end of list notification 
                 }
-                
+
             } else {
                 //See step 5 below (move filtered lowerLevelResults data to higher level cache and return this to user)
                 const closestUsers = await makeUserSpecificEntry(lowerLevelResults, searchQuery, req.session.userId);
@@ -60,16 +60,15 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
                 //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
                 if (closestUsers === null) {
                     if (lowerLevelResults.length > NUM_RESULTS_PER_CALL) {
-                        res.status(201).json({results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}`}); //send back LL15 if exists
+                        res.status(201).json({ results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` }); 
                     } else {
-                        res.status(201).json({results: lowerLevelResults, newPageMarker: 'END' });
+                        res.status(201).json({ results: lowerLevelResults, newPageMarker: 'END' });
                     }
                 } else {
                     //return these prioritzed and specialized results to the user
-                    res.status(201).json({results: closestUsers, newPageMarker: 'LL0'}); //send back LL0
+                    res.status(201).json({ results: closestUsers, newPageMarker: 'LL0' }); //send back LL0
                 }
             }
-            
 
         //---Step 3: cache miss, so load from database---//
         } else {
@@ -77,51 +76,53 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
             //note: learned about usage of spread operator for conditional where clause in prisma from here: https://stackoverflow.com/questions/72197774/how-to-call-where-clause-conditionally-prisma
             const userResults = await prisma.user.findMany({
                 where: {
-                        ...( lastWord ? {
-                                AND: [
-                                    { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
-                                    { userProfile: { lastName: { startsWith: lastWord, mode: 'insensitive' } } },
-                                ]
-                            }
-                            : 
-                            {
-                                OR: [
-                                    { username: { startsWith: firstWord, mode: 'insensitive' } },
-                                    { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
-                                    { userProfile: { lastName: { startsWith: firstWord, mode: 'insensitive' } } },
-                                ]
-                            }
-                        )
-                    },
-                    select: { username: true, id: true }
+                    ...(lastWord ? {
+                        AND: [
+                            { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
+                            { userProfile: { lastName: { startsWith: lastWord, mode: 'insensitive' } } },
+                        ]
+                    }
+                        :
+                        {
+                            OR: [
+                                { username: { startsWith: firstWord, mode: 'insensitive' } },
+                                { userProfile: { firstName: { startsWith: firstWord, mode: 'insensitive' } } },
+                                { userProfile: { lastName: { startsWith: firstWord, mode: 'insensitive' } } },
+                            ]
+                        }
+                    )
+                },
+                select: { username: true, id: true }
             })
 
             //---Step 4: store in lower level cache---//
             serverSideCache.insertGlobalUserCache(searchQuery, userResults);
 
+            // TODO: combine below with above similar structure
             if (pageMarker.startsWith('L')) {
                 if ((userResults.length > pageIndex) && (userResults.length > pageIndex + NUM_RESULTS_PER_CALL)) {
-                    res.status(201).json({results: userResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}`}); //send back LL+15 if exists
+                    res.status(201).json({ results: userResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` }); 
                 } else {
-                    res.status(201).json({results: userResults.slice(pageIndex), newPageMarker: 'END'}); //send back end of list
+                    res.status(201).json({ results: userResults.slice(pageIndex), newPageMarker: 'END' }); //send back end of list
                 }
             } else {
                 //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
-                const closestUsers = await makeUserSpecificEntry(userResults, searchQuery, req.session.userId); 
+                const closestUsers = await makeUserSpecificEntry(userResults, searchQuery, req.session.userId);
 
                 //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
                 if (closestUsers === null) {
                     if (userResults.length > NUM_RESULTS_PER_CALL) {
-                        res.status(201).json({results: userResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}`}); //send back LL15 if exists
+                        res.status(201).json({ results: userResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` }); 
                     } else {
-                        res.status(201).json({results: userResults, newPageMarker: 'END' }); 
+                        res.status(201).json({ results: userResults, newPageMarker: 'END' });
                     }
                 } else {
                     //return these prioritzed and specialized results to the user
-                    res.status(201).json({results: closestUsers, newPageMarker: 'LL0'}); //send back LL0
+                    res.status(201).json({ results: closestUsers, newPageMarker: 'LL0' }); //send back LL0
                 }
             }
             
+
         }
 
     } catch (error) {
@@ -137,16 +138,16 @@ const makeUserSpecificEntry = async (userResults, searchQuery, userId) => {
     const closestUsers = []
     for (user of userResults) {
         if (groupMatesMap.has(user.id)) {
-            closestUsers.push({...user, numMutualGroups: groupMatesMap.get(user.id)})
+            closestUsers.push({ ...user, numMutualGroups: groupMatesMap.get(user.id) })
         }
     }
 
     if (closestUsers.length === 0) {
-        //no value to insert into user-specific cache, but need to store the searchQuery-userId key so that we know this search was made
-        serverSideCache.insertUserSpecificCache(searchQuery, null, userId) 
+        //no value to insert into user-specific cache, but need to store the userId+searchQuery key so that we know this search was made
+        serverSideCache.insertUserSpecificCache(searchQuery, null, userId)
         return null;
     }
-    
+
     //sort based on users with most amount of matching groups
     closestUsers.sort((a, b) => b.numMutualGroups - a.numMutualGroups)
 


### PR DESCRIPTION
## Description

**Done in this PR**
-User can now load more search results on their page if it exists. At first, the results of users with a matching group to the user show up, then, on load more, additional results would show up. 

**Technical complexities and considerations**
-I designed and implemented a sort of pagination/marker technique for my cached data so that not all data is sent to the frontend at once. Only if the user wants more data, do we have to go back to the cache and load more to the frontend, improving performance. Additionally, by using the higher level cache and loading only immediate group mates first, the user will likely not need to continue searching because they are likely just searching for a group member.

-Duplicates will need to be handled on the frontend, so I decided to use a JS Set for the currently loaded user Ids which improves the performance of checking against duplicates of newly loaded data.

**Done in upcoming PRs**
-Implement filtering of displayed results by user's interests
-continue to clean up code, especially in userSearch.js
-fix small bugs and UI inconsistencies like load button and autocomplete moving around
-Implement TTL for caches

## Milestones
-User can search for other other users with tailored results and the ability to load more results if desired

## Resources
https://react.dev/reference/react/useRef

## Test Plan
https://www.loom.com/share/681826f9cd734f9cbce9915acc294050
