### PR TITLE
Implemented filtering on search results - FE and BE changes

### DIFF
--- a/client/src/components/FilterDropDown.jsx
+++ b/client/src/components/FilterDropDown.jsx
@@ -1,0 +1,48 @@
+import { useState, useEffect, Suspense } from "react";
+import APIUtils from "../utils/APIUtils";
+import "../styles/FilterDropDown.css";
+
+const FilterDropDown = ({ onFilterChange }) => {
+
+    const [userInterests, setUserInterests] = useState([]);
+
+    useEffect(() => {
+        fetchUserInterests();
+    }, [])
+
+    const fetchUserInterests = async () => {
+        try {
+            const apiResultData = await APIUtils.fetchUserInterests();
+            if (apiResultData.length >= 1) {
+                setUserInterests(apiResultData);
+            }
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
+    }
+
+    const handleSelect = (event) => {
+        onFilterChange(event.target.value)
+    }
+
+    return (
+        <div className="filter-container">
+            <label>Filter by your interests:</label>
+            <select name="interests" id="interests" defaultValue="" onChange={handleSelect}>
+                <option disabled value="">Select interest...</option>
+                <option value={-1}>None</option>
+                <Suspense fallback={<p>Loading...</p>}>
+                    {userInterests.map((interest) => {
+                        return <option key={interest.id} value={interest.id}>{interest.title}</option>
+                    })}
+                
+                </Suspense>
+            </select>
+        </div>
+
+    )
+}
+
+
+export default FilterDropDown;

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -1,6 +1,7 @@
 import { useState, Suspense, useMemo, useEffect, useRef } from "react";
 import NavBar from "../components/NavBar"
 import UserResultCard from "../components/UserResultCard";
+import FilterDropDown from "../components/FilterDropDown";
 import APIUtils from "../utils/APIUtils";
 import "../styles/SearchResultsPage.css"
 import "../styles/CardListContainer.css"
@@ -9,6 +10,7 @@ const SearchResultsPage = () => {
 
     const [searchQuery, setSearchQuery] = useState("");
     const [searchResults, setSearchResults] = useState([]);
+    const [interestIdFilter, setInterestIdFilter] = useState(-1); //interest id used for filtering user resukts by ones that have this selected interest
     const [notif, setNotif] = useState("User results will show up here..."); //TODO: make notification better appearance and closer to search bar
     const [isDisplayedAutocompleteSuggestions, setIsDisplayedAutocompleteSuggestions] = useState(false);
     const [autocompleteSuggestions, setAutocompleteSuggestions] = useState(new Set());
@@ -28,6 +30,19 @@ const SearchResultsPage = () => {
         },
         [autocompleteSuggestions, searchQuery]
     );
+    const displayedSearchResults = useMemo(
+        () => {
+            if (interestIdFilter === -1) return searchResults;
+            console.log(searchResults)
+            console.log("filter: ", interestIdFilter)
+            const filteredSearchResults = searchResults.filter((user)  => 
+                user.interests.includes(interestIdFilter)
+            )
+            console.log("filtered: ", filteredSearchResults);
+            return filteredSearchResults;
+        },
+        [searchResults, interestIdFilter]
+    )
 
     useEffect(() => {
         fetchAutocompleteSuggestions();
@@ -100,6 +115,7 @@ const SearchResultsPage = () => {
         <div id="search-page">
             <NavBar />
             <div className="search-area">
+                <FilterDropDown onFilterChange={(filter) => {setInterestIdFilter(parseInt(filter))}}/>
                 <form onSubmit={(event) => {
                         event.preventDefault();
                         pageMarker.current = 'HL0';
@@ -133,7 +149,7 @@ const SearchResultsPage = () => {
                 {searchResults.length < 1 ? <p className="notif-para">{notif}</p> :
                     <div className="card-container">
                         <Suspense fallback={<p>Loading...</p>}>
-                            {searchResults.map((userObj) => {
+                            {displayedSearchResults.map((userObj) => {
                                 return <UserResultCard 
                                     key={userObj.id}
                                     username={userObj.username}

--- a/client/src/styles/FilterDropDown.css
+++ b/client/src/styles/FilterDropDown.css
@@ -1,0 +1,3 @@
+.filter-container {
+    margin-top: 20px;
+}

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -46,29 +46,8 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
 
         //---Step 2: check lower level cache---//
         } else if (lowerLevelResults) { //cache hit
-            if (pageMarker.startsWith('L')) {
-                if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) { //ensure index increment is still within array size
-                    res.status(201).json({ results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` });
-                } else {
-                    res.status(201).json({ results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END' }); //send back end of list notification 
-                }
-
-            } else {
-                //See step 5 below (move filtered lowerLevelResults data to higher level cache and return this to user)
-                const closestUsers = await makeUserSpecificEntry(lowerLevelResults, searchQuery, req.session.userId);
-
-                //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
-                if (closestUsers === null) {
-                    if (lowerLevelResults.length > NUM_RESULTS_PER_CALL) {
-                        res.status(201).json({ results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` }); 
-                    } else {
-                        res.status(201).json({ results: lowerLevelResults, newPageMarker: 'END' });
-                    }
-                } else {
-                    //return these prioritzed and specialized results to the user
-                    res.status(201).json({ results: closestUsers, newPageMarker: 'LL0' }); //send back LL0
-                }
-            }
+            const returnedLowerLevelData = await getLowerLevelData(lowerLevelResults, req.session.userId, searchQuery, pageMarker, pageIndex);
+            res.status(201).json(returnedLowerLevelData);
 
         //---Step 3: cache miss, so load from database---//
         } else {
@@ -95,39 +74,19 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
                 select: { username: true, id: true, interests: { select: { id: true } } }
             })
 
-            for(let i = 0; i < userResults.length; i++) {
+            //make sure interests are stored as just an array of interest ids - not an array of objects like {id: 1}. This will make filtering on frontend easier later
+            for (let i = 0; i < userResults.length; i++) {
                 const refactoredInterestList = userResults[i].interests.map((interest) => {
                     return interest.id
                 })
                 userResults[i].interests = refactoredInterestList;
             }
+
             //---Step 4: store in lower level cache---//
             serverSideCache.insertGlobalUserCache(searchQuery, userResults);
 
-            // TODO: combine below with above similar structure
-            if (pageMarker.startsWith('L')) {
-                if ((userResults.length > pageIndex) && (userResults.length > pageIndex + NUM_RESULTS_PER_CALL)) {
-                    res.status(201).json({ results: userResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` }); 
-                } else {
-                    res.status(201).json({ results: userResults.slice(pageIndex), newPageMarker: 'END' }); //send back end of list
-                }
-            } else {
-                //---Step 5: store only users in same groups in higher level cache and sort by highest amount of shared groups---//
-                const closestUsers = await makeUserSpecificEntry(userResults, searchQuery, req.session.userId);
-
-                //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
-                if (closestUsers === null) {
-                    if (userResults.length > NUM_RESULTS_PER_CALL) {
-                        res.status(201).json({ results: userResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` }); 
-                    } else {
-                        res.status(201).json({ results: userResults, newPageMarker: 'END' });
-                    }
-                } else {
-                    //return these prioritzed and specialized results to the user
-                    res.status(201).json({ results: closestUsers, newPageMarker: 'LL0' }); //send back LL0
-                }
-            }
-            
+            const returnedLowerLevelData = await getLowerLevelData(userResults, req.session.userId, searchQuery, pageMarker, pageIndex);
+            res.status(201).json(returnedLowerLevelData);
 
         }
 
@@ -137,6 +96,35 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
     }
 })
 
+/*This function gets next section of data from lower cache if page marker starts with 'L'.
+If starts with 'H', it triggers makeUserSpecificEntry to get filtered data into HL cache and returns that if exists (else, just returns lower level cache first set of items)*/
+const getLowerLevelData = async (lowerLevelResults, userId, searchQuery, pageMarker, pageIndex) => {
+    if (pageMarker.startsWith('L')) {
+        if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) { //ensure index increment is still within array size
+            return { results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` };
+        } else {
+            return { results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END' }; //send back end of list notification 
+        }
+
+    } else {
+        //See below (move filtered lowerLevelResults data to higher level cache and return this to user)
+        const closestUsers = await makeUserSpecificEntry(lowerLevelResults, searchQuery, userId);
+
+        //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
+        if (closestUsers === null) {
+            if (lowerLevelResults.length > NUM_RESULTS_PER_CALL) {
+                return { results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` };
+            } else {
+                return { results: lowerLevelResults, newPageMarker: 'END' };
+            }
+        } else {
+            //return these prioritzed and specialized results to the user
+            return { results: closestUsers, newPageMarker: 'LL0' }; //send back LL0
+        }
+    }
+}
+
+//This function filters and stores users from lower level cache results that are in a group with current user into the higher level cache
 const makeUserSpecificEntry = async (userResults, searchQuery, userId) => {
     const groupMatesMap = await getOtherGroupMembers(userId);
 

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -92,9 +92,15 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
                         }
                     )
                 },
-                select: { username: true, id: true }
+                select: { username: true, id: true, interests: { select: { id: true } } }
             })
 
+            for(let i = 0; i < userResults.length; i++) {
+                const refactoredInterestList = userResults[i].interests.map((interest) => {
+                    return interest.id
+                })
+                userResults[i].interests = refactoredInterestList;
+            }
             //---Step 4: store in lower level cache---//
             serverSideCache.insertGlobalUserCache(searchQuery, userResults);
 


### PR DESCRIPTION
## Description

**Done in this PR**
-User can now filter displayed searched user results by their selected interests. If a user has also selected the same interest they will remain onscreen. After this filter is set, it applies to additionally loaded data.
-I also fixed a ui bug where a new search query was not clearing existing displayed results.
-Continued to refactor code and include comments

**Done in upcoming PRs**
-Include count of amount of user results on page with each selected interest in the filter dropdown
-Improve UI of search page. Especially load button and autocomplete suggestions not staying in one place.
-Implement TTL for caches
-Move onto additional capstone requirements including public api implementation and visual requirements

## Milestones
-User can filter down searched results by their interests to find users they may be compatible with 

## Resources
https://react.dev/reference/react-dom/components/select

## Test Plan
-NOTE: In this example, the users with usernames including "connected" have been signed up and selected tennis as an interest. the other 'Jacob' results have no selected interests.
https://www.loom.com/share/3ae859500c054fb5900b8e7c1a5c632d
