### PR TITLE
Filtering options now have tallies of the number of user results that have that selected interest - FE and BE changes

### DIFF
--- a/client/src/components/FilterDropDown.jsx
+++ b/client/src/components/FilterDropDown.jsx
@@ -1,27 +1,7 @@
-import { useState, useEffect, Suspense } from "react";
-import APIUtils from "../utils/APIUtils";
+import { Suspense } from "react";
 import "../styles/FilterDropDown.css";
 
-const FilterDropDown = ({ onFilterChange }) => {
-
-    const [userInterests, setUserInterests] = useState([]);
-
-    useEffect(() => {
-        fetchUserInterests();
-    }, [])
-
-    const fetchUserInterests = async () => {
-        try {
-            const apiResultData = await APIUtils.fetchUserInterests();
-            if (apiResultData.length >= 1) {
-                setUserInterests(apiResultData);
-            }
-        } catch (error) {
-            console.log("Status ", error.status);
-            console.log("Error: ", error.message);
-        }
-    }
-
+const FilterDropDown = ({ onFilterChange, userInterests }) => {
     const handleSelect = (event) => {
         onFilterChange(event.target.value)
     }
@@ -33,10 +13,9 @@ const FilterDropDown = ({ onFilterChange }) => {
                 <option disabled value="">Select interest...</option>
                 <option value={-1}>None</option>
                 <Suspense fallback={<p>Loading...</p>}>
-                    {userInterests.map((interest) => {
-                        return <option key={interest.id} value={interest.id}>{interest.title}</option>
+                    {Array.from(userInterests.entries()).map(([key, value]) => {
+                        return <option key={key} value={value.id}>{value.title} {value.tally}</option>
                     })}
-                
                 </Suspense>
             </select>
         </div>

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -8,7 +8,10 @@ import "../styles/CardListContainer.css"
 
 const SearchResultsPage = () => {
 
+    //create interest to users inverted index. as results come in put into relative interest
+
     let searchIsReset = false; //set to true when search is triggered - NOT when load more is triggered
+    const [userInterestMap, setUserInterestMap] = useState(new Map());
     const [searchQuery, setSearchQuery] = useState("");
     const [searchResults, setSearchResults] = useState([]);
     const [interestIdFilter, setInterestIdFilter] = useState(-1); //interest id used for filtering user resukts by ones that have this selected interest
@@ -21,20 +24,20 @@ const SearchResultsPage = () => {
         () => {
             if (searchQuery === "") {
                 return autocompleteSuggestions;
-            } else { 
+            } else {
                 const filteredSuggestions = Array.from(autocompleteSuggestions).filter((suggestion) => {
                     return suggestion.startsWith(searchQuery)
                 })
                 return filteredSuggestions
             }
-            
+
         },
         [autocompleteSuggestions, searchQuery]
     );
     const displayedSearchResults = useMemo(
         () => {
             if (interestIdFilter === -1) return searchResults;
-            const filteredSearchResults = searchResults.filter((user)  => 
+            const filteredSearchResults = searchResults.filter((user) =>
                 user.interests.includes(interestIdFilter)
             )
             return filteredSearchResults;
@@ -44,7 +47,24 @@ const SearchResultsPage = () => {
 
     useEffect(() => {
         fetchAutocompleteSuggestions();
+        fetchUserInterests();
     }, []);
+
+    const fetchUserInterests = async () => {
+        try {
+            const apiResultData = await APIUtils.fetchUserInterests();
+            let tempMap = new Map();
+            if (apiResultData.length >= 1) {
+                for (let i = 0; i < apiResultData.length; i++) {
+                    tempMap.set(apiResultData[i].id, apiResultData[i]);
+                }
+            }
+            setUserInterestMap(tempMap);
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
+    }
 
     const fetchAutocompleteSuggestions = async () => {
         try {
@@ -77,18 +97,31 @@ const SearchResultsPage = () => {
             } else {
                 setAutocompleteSuggestions(new Set([...prevSetAsArr, searchQuery]))
             }
-                
+
             try {
                 //get user object results from backend
                 let apiResultData = {}
+
+                const objUserInterests = {
+                    userInterests: Array.from(userInterestMap.keys())
+                }
                 if (searchQuery === "") {
-                    apiResultData = await APIUtils.userSearch(suggestion, pageMarker.current);
+                    apiResultData = await APIUtils.userSearch(suggestion, pageMarker.current, objUserInterests);
                 } else {
-                    apiResultData = await APIUtils.userSearch(searchQuery, pageMarker.current);
+                    apiResultData = await APIUtils.userSearch(searchQuery, pageMarker.current, objUserInterests);
                 }
                 setIsLoadMoreHidden(apiResultData.newPageMarker === 'END');
-                
+
                 pageMarker.current = apiResultData.newPageMarker;
+
+                if (apiResultData.userInterestMap) {
+                    let updatedUserInterestMap = new Map()
+                    for (let i = 0; i < apiResultData.userInterestMap.length; i++) {
+                        updatedUserInterestMap.set(apiResultData.userInterestMap[i][0], {...userInterestMap.get(apiResultData.userInterestMap[i][0]), tally: apiResultData.userInterestMap[i][1]})
+                    }
+                
+                    setUserInterestMap(updatedUserInterestMap);
+                }
 
                 if (apiResultData.results.length === 0) {
                     setNotif("No results found!")
@@ -102,7 +135,7 @@ const SearchResultsPage = () => {
                             return !currentResultsIds.has(newResult.id) //having created a set makes this operation O(1)
                         })
                         setSearchResults([...searchResults, ...filteredNewResults]);
-                    }  
+                    }
                 }
                 searchIsReset = false;
             } catch (error) {
@@ -110,56 +143,56 @@ const SearchResultsPage = () => {
                 console.log("Error: ", error.message);
             }
         }
-        
+
     }
 
-   
+
     return (
         <div id="search-page">
             <NavBar />
             <div className="search-area">
-                <FilterDropDown onFilterChange={(filter) => {setInterestIdFilter(parseInt(filter))}}/>
+                <FilterDropDown onFilterChange={(filter) => { setInterestIdFilter(parseInt(filter)) }} userInterests={userInterestMap}/>
                 <form onSubmit={(event) => {
-                        event.preventDefault();
-                        searchIsReset = true;
-                        pageMarker.current = 'HL0';
-                        handleSearchSubmit();
-                    }}>
-                    <input className="search-input" value={searchQuery} placeholder="Search users..." onFocus={() => setIsDisplayedAutocompleteSuggestions(true)} onBlur={(event) => setIsDisplayedAutocompleteSuggestions(false)} onChange={handleQueryChange}/>
+                    event.preventDefault();
+                    searchIsReset = true;
+                    pageMarker.current = 'HL0';
+                    handleSearchSubmit();
+                }}>
+                    <input className="search-input" value={searchQuery} placeholder="Search users..." onFocus={() => setIsDisplayedAutocompleteSuggestions(true)} onBlur={(event) => setIsDisplayedAutocompleteSuggestions(false)} onChange={handleQueryChange} />
                     <button type="submit" className="search-btn">Search</button>
                 </form>
                 {isDisplayedAutocompleteSuggestions &&
                     <Suspense fallback={<p>Loading...</p>}>
                         {Array.from(displayedAutocompleteSuggestions).slice(0).reverse().slice(0, 5).map((suggestion, index) => { //need to reverse because sets/maps maintain order by insertion and we want order by recency
-                            return <div 
-                                    className="autocomplete-recommendation"
-                                    key={suggestion + index} 
-                                    onMouseDown={() => { //used onMouseDown to activate before onBlur
-                                        setSearchQuery(suggestion);
-                                        pageMarker.current = 'HL0';
-                                        searchIsReset = true;
-                                        handleSearchSubmit(suggestion);
-                                    }}
-                                >
-                                    {suggestion}
-                                </div>
+                            return <div
+                                className="autocomplete-recommendation"
+                                key={suggestion + index}
+                                onMouseDown={() => { //used onMouseDown to activate before onBlur
+                                    setSearchQuery(suggestion);
+                                    pageMarker.current = 'HL0';
+                                    searchIsReset = true;
+                                    handleSearchSubmit(suggestion);
+                                }}
+                            >
+                                {suggestion}
+                            </div>
                         })}
                     </Suspense>
-                } 
+                }
             </div>
-            
+
             <div className="user-results-list">
                 {searchResults.length < 1 ? <p className="notif-para">{notif}</p> :
                     <div className="card-container">
                         <Suspense fallback={<p>Loading...</p>}>
                             {displayedSearchResults.map((userObj) => {
-                                return <UserResultCard 
+                                return <UserResultCard
                                     key={userObj.id}
                                     username={userObj.username}
                                     numMutualGroups={userObj.numMutualGroups}
                                 />
                             })}
-                        </Suspense> 
+                        </Suspense>
                     </div>
                 }
                 {!isLoadMoreHidden && <button className="load-more-btn" onClick={handleSearchSubmit}>Load More</button>}

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -7,11 +7,8 @@ import "../styles/SearchResultsPage.css"
 import "../styles/CardListContainer.css"
 
 const SearchResultsPage = () => {
-
-    //create interest to users inverted index. as results come in put into relative interest
-
     let searchIsReset = false; //set to true when search is triggered - NOT when load more is triggered
-    const [userInterestMap, setUserInterestMap] = useState(new Map());
+    const [userInterestMap, setUserInterestMap] = useState(new Map()); //map of user interest selected ids (keys) to the interest object. tallies for each will be loaded on backend
     const [searchQuery, setSearchQuery] = useState("");
     const [searchResults, setSearchResults] = useState([]);
     const [interestIdFilter, setInterestIdFilter] = useState(-1); //interest id used for filtering user resukts by ones that have this selected interest
@@ -101,9 +98,15 @@ const SearchResultsPage = () => {
             try {
                 //get user object results from backend
                 let apiResultData = {}
-
-                const objUserInterests = {
-                    userInterests: Array.from(userInterestMap.keys())
+                let objUserInterests = {}
+                if(searchIsReset) { //if it's a new search and not just load more
+                    objUserInterests = {
+                        userInterests: Array.from(userInterestMap.keys())
+                    }
+                } else {
+                    objUserInterests = {
+                        userInterests: []
+                    }
                 }
                 if (searchQuery === "") {
                     apiResultData = await APIUtils.userSearch(suggestion, pageMarker.current, objUserInterests);
@@ -114,6 +117,7 @@ const SearchResultsPage = () => {
 
                 pageMarker.current = apiResultData.newPageMarker;
 
+                //update userInterest map with tallies from backend
                 if (apiResultData.userInterestMap) {
                     let updatedUserInterestMap = new Map()
                     for (let i = 0; i < apiResultData.userInterestMap.length; i++) {

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -99,7 +99,7 @@ const SearchResultsPage = () => {
                 //get user object results from backend
                 let apiResultData = {}
                 let objUserInterests = {}
-                if(searchIsReset) { //if it's a new search and not just load more
+                if(searchIsReset) { //if it's a new search and not just load more, then send user's selected interests to the backend.
                     objUserInterests = {
                         userInterests: Array.from(userInterestMap.keys())
                     }
@@ -108,11 +108,13 @@ const SearchResultsPage = () => {
                         userInterests: []
                     }
                 }
+
                 if (searchQuery === "") {
                     apiResultData = await APIUtils.userSearch(suggestion, pageMarker.current, objUserInterests);
                 } else {
                     apiResultData = await APIUtils.userSearch(searchQuery, pageMarker.current, objUserInterests);
                 }
+                
                 setIsLoadMoreHidden(apiResultData.newPageMarker === 'END');
 
                 pageMarker.current = apiResultData.newPageMarker;

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -206,11 +206,12 @@ export default class APIUtils {
         }
     }
 
-    static userSearch = async (searchQuery, pageMarker) => {
+    static userSearch = async (searchQuery, pageMarker, userInterests) => {
         const response = await fetch(`http://localhost:3000/search/users/?searchQuery=${searchQuery}&pageMarker=${pageMarker}`, {
-            method: "GET",
+            method: "POST",
             headers: { "Content-Type": "application/json" },
             credentials: "include",
+            body: JSON.stringify(userInterests),
         });
 
         const data = await response.json();

--- a/server/routes/userSearch.js
+++ b/server/routes/userSearch.js
@@ -21,10 +21,16 @@ router.get('/search/users/typeahead', isAuthenticated, async (req, res) => {
 })
 
 //user search endpoint
-router.get('/search/users', isAuthenticated, async (req, res) => {
+router.post('/search/users', isAuthenticated, async (req, res) => {
 
     const { searchQuery, pageMarker } = req.query;
+    const { userInterests } = req.body;
 
+    const userInterestMap = new Map();
+    for (userInterestId of userInterests) {
+        userInterestMap.set(userInterestId, 0);
+    }
+   
     const pageIndex = parseInt(pageMarker.charAt(2));
 
     /*note: usernames should be one word, so if the search query had a space, that means the user is searching for a first and last name. If there is a second keyword, search by matching
@@ -76,16 +82,21 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
 
             //make sure interests are stored as just an array of interest ids - not an array of objects like {id: 1}. This will make filtering on frontend easier later
             for (let i = 0; i < userResults.length; i++) {
-                const refactoredInterestList = userResults[i].interests.map((interest) => {
-                    return interest.id
-                })
+                //for all interests for each user, if it is one of the keys in user interest inverted index, add to tally
+                let refactoredInterestList = [];
+                for (interest of userResults[i].interests) {
+                    if (userInterestMap.has(interest.id)) {
+                        userInterestMap.set(interest.id, userInterestMap.get(interest.id) + 1)
+                    }
+                    refactoredInterestList.push(interest.id)
+                }
                 userResults[i].interests = refactoredInterestList;
             }
 
             //---Step 4: store in lower level cache---//
             serverSideCache.insertGlobalUserCache(searchQuery, userResults);
 
-            const returnedLowerLevelData = await getLowerLevelData(userResults, req.session.userId, searchQuery, pageMarker, pageIndex);
+            const returnedLowerLevelData = await getLowerLevelData(userResults, req.session.userId, searchQuery, pageMarker, pageIndex, userInterestMap);
             res.status(201).json(returnedLowerLevelData);
 
         }
@@ -98,12 +109,13 @@ router.get('/search/users', isAuthenticated, async (req, res) => {
 
 /*This function gets next section of data from lower cache if page marker starts with 'L'.
 If starts with 'H', it triggers makeUserSpecificEntry to get filtered data into HL cache and returns that if exists (else, just returns lower level cache first set of items)*/
-const getLowerLevelData = async (lowerLevelResults, userId, searchQuery, pageMarker, pageIndex) => {
+const getLowerLevelData = async (lowerLevelResults, userId, searchQuery, pageMarker, pageIndex, userInterestMap) => {
+    const sentUserInterestMap = (userInterestMap == undefined)? null : [...userInterestMap.entries()]
     if (pageMarker.startsWith('L')) {
         if ((lowerLevelResults.length > pageIndex) && (lowerLevelResults.length > pageIndex + NUM_RESULTS_PER_CALL)) { //ensure index increment is still within array size
-            return { results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}` };
+            return { results: lowerLevelResults.slice(pageIndex, pageIndex + NUM_RESULTS_PER_CALL), newPageMarker: `LL${pageIndex + NUM_RESULTS_PER_CALL}`, userInterestMap: sentUserInterestMap};
         } else {
-            return { results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END' }; //send back end of list notification 
+            return { results: lowerLevelResults.slice(pageIndex), newPageMarker: 'END', userInterestMap: sentUserInterestMap }; //send back end of list notification 
         }
 
     } else {
@@ -113,13 +125,13 @@ const getLowerLevelData = async (lowerLevelResults, userId, searchQuery, pageMar
         //if the users from lower level cache for this searchQuery have no relation to current user, nothing new will be stored in user-specific cache, so just return result from lower level cache
         if (closestUsers === null) {
             if (lowerLevelResults.length > NUM_RESULTS_PER_CALL) {
-                return { results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}` };
+                return { results: lowerLevelResults.slice(0, NUM_RESULTS_PER_CALL), newPageMarker: `LL${NUM_RESULTS_PER_CALL}`, userInterestMap: sentUserInterestMap };
             } else {
-                return { results: lowerLevelResults, newPageMarker: 'END' };
+                return { results: lowerLevelResults, newPageMarker: 'END', userInterestMap: sentUserInterestMap };
             }
         } else {
             //return these prioritzed and specialized results to the user
-            return { results: closestUsers, newPageMarker: 'LL0' }; //send back LL0
+            return { results: closestUsers, newPageMarker: 'LL0', userInterestMap: sentUserInterestMap}; //send back LL0
         }
     }
 }


### PR DESCRIPTION
## Description

**Done in this PR**
-Now after user hist 'search' the filter dropdown will have a number/tally next to every interest, indicating the number of user results that have that interest selected.
-Note: these numbers apply to all user results, not just those currently onscreen - that was my understanding of the requirement.
**Technical complexities and considerations**
-Already needed a for loop for creating interest array for users loaded from database, so I also put the user interest check there to avoid another loop through all loaded users from database

-My goal was to get the tallies for all user results (including the ones they would see if they kept loading more). This meant I had to iterate through all users in the search query’s entry in the lower level cache for every new search. I was unable to brainstorm another way of getting the tallies for all results rather than just those shown onscreen. If this is an optimization concern, should I instead switch to tallies pertaining to what’s onscreen? Or is there a common practice like displaying estimates rather than exact tallies that I should consider instead?

-I ensured tally calculations only occur on new searches and not unnecessarily for load more calls.

**Done in upcoming PRs**
-TTL implementation
-Implement public API for string Address to coordinates when user signs up
-Work on visual styling requirements and improvements on UI

## Milestones
-Users can filter their search results by their own interests to find people compatible with them

## Resources
https://stackoverflow.com/questions/28718641/transforming-a-javascript-iterable-into-an-array

## Test Plan
https://www.loom.com/share/604b79ab1c9842b48fb323e9aabb0372
