### PR TITLE
Implemented Third-Party API, OpenCage, so users can now sign up with an address and coordinates will be stored in DB

### DIFF
--- a/client/src/components/FilterOptions.jsx
+++ b/client/src/components/FilterOptions.jsx
@@ -9,7 +9,7 @@ const FilterOptions = ( {onFilterChange}) => {
     return <div className="filter-form">
         {
             Object.values(Status).map((status) => (
-                <button key={status} value={status} onClick={handleFilterClick}>{status}</button>
+                <button className="filter-btn" key={status} value={status} onClick={handleFilterClick}>{status}</button>
             ))
         }
     </div>

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -52,7 +52,7 @@ const GroupsList = () => {
                             if (isGroupErased) { //when no members remain, group is erased from DB, so delete from state
                                 updatedGroups.delete(groupId);
                             } else {
-                                updatedGroups.set(newGroupObj.group_id, newGroupObj);
+                                updatedGroups.set(groupId, newGroupObj);
                             }
                             setGroups(updatedGroups);
                         }}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,8 @@
         "express-rate-limit": "^7.5.1",
         "express-session": "^1.18.1",
         "geokdbush": "^2.0.1",
-        "kdbush": "^4.0.2"
+        "kdbush": "^4.0.2",
+        "opencage-api-client": "^2.0.0"
       },
       "devDependencies": {
         "prisma": "^6.10.1"
@@ -774,6 +775,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/opencage-api-client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/opencage-api-client/-/opencage-api-client-2.0.0.tgz",
+      "integrity": "sha512-XoRp7lI3msYYwVl2abgfNkQ3MDS94OsLMaOtMm4cfh4UwgtaSyVV/xeYK4jNnPhxx8Bo+AX5cYXF+7hspSLsiw==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,8 @@
     "express-rate-limit": "^7.5.1",
     "express-session": "^1.18.1",
     "geokdbush": "^2.0.1",
-    "kdbush": "^4.0.2"
+    "kdbush": "^4.0.2",
+    "opencage-api-client": "^2.0.0"
   },
   "devDependencies": {
     "prisma": "^6.10.1"

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -6,6 +6,8 @@ const prisma = new PrismaClient()
 const router = express.Router()
 const rateLimit = require("express-rate-limit");
 
+const opencage = require('opencage-api-client'); //public api
+
 const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5, // Limit each IP to 5 login attempts per windowMs
@@ -19,8 +21,8 @@ router.post('/signup', async (req, res) => {
     const { address, username, email, password, firstName, lastName } = req.body;
 
     try {
-        if (!username || !email || !password || !firstName || !lastName) {
-            return res.status(400).json({ error: "First name, last name, username, email, and password are required." });
+        if (!username || !email || !password || !firstName || !lastName || !address) {
+            return res.status(400).json({ error: "First name, last name, address, username, email, and password are required." });
         }
 
         if (password.length < 8) {
@@ -45,12 +47,36 @@ router.post('/signup', async (req, res) => {
             return res.status(400).json({ error: "Account already created with this email" })
         }
 
+        let userCoords = {latitude: null,longitude: null}
+
+        /*****Forward geocoding of provided address - the following code has been implmented and modified based on the
+        example implementation from api documentation: https://opencagedata.com/tutorials/geocode-in-nodejs ***********/
+        await opencage
+        .geocode({ q: address })
+        .then((data) => {
+            if (data.status.code === 200 && data.results.length > 0) {
+                const place = data.results[0];
+                userCoords.latitude = place.geometry.lat;
+                userCoords.longitude = place.geometry.lng;
+            } else {
+                console.log('Status', data.status.message);
+                console.log('total_results', data.total_results);
+            }
+        })
+        .catch((error) => {
+            console.log('Error', error.message);
+            if (error.status.code === 402) {
+                console.log('Request limit reached');
+            }
+        });
+        /************************************* end of code from third-party api documentation *********************************/
+
         // Hash the password before storing it
         const hashedPassword = await bcrypt.hash(password, saltRounds)
 
         // Create a new user in the database
         //for mock data, have all users start out with location at meta's headquarters
-        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${-122.1500}, ${37.485949}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
+        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${userCoords.longitude}, ${userCoords.latitude}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
 
         const newUser = queryResult.at(0);
         // Store user ID and username in the session, allowing them to remain authenticated as they navigate the website

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -49,7 +49,7 @@ router.post('/signup', async (req, res) => {
 
         let userCoords = {latitude: null,longitude: null}
 
-        /*****Forward geocoding of provided address - the following code has been implmented and modified based on the
+        /*****Forward geocoding of provided address - the following code has been implemented and modified based on the
         example implementation from api documentation: https://opencagedata.com/tutorials/geocode-in-nodejs ***********/
         await opencage
         .geocode({ q: address })


### PR DESCRIPTION
## Description

**Done in this PR**
-Implemented OpenCage API in the user sign up endpoint so that when they enter an address it is converted to coordinates with forward geocoding. These coordinates are then stored in the database.

**Done in upcoming PRs**
-Finish TC 2 by adding TTL to my caches.
-Continue to implement more feedback from past PRs
-Work on UI styling and capstone visual requirements
-Set up timed triggering of event search endpoint

## Milestones
-User can include their address on sign up to only get groups and events near them

## Resources
OpenCage documentation code for Node.js implementation: https://opencagedata.com/tutorials/geocode-in-nodejs

## Test Plan
Tested by signing up a user with the Meta Seattle address. They did not get any group recs because all groups are in MPK. When another user was signed up with the Seattle address, they were recommended the group created by the first user in Seattle.
