### PR TITLE
Event invites now sent to users who joined the group later. Event matching algo triggering set up - BE Changes

### DIFF
--- a/client/src/components/SelectedInterests.jsx
+++ b/client/src/components/SelectedInterests.jsx
@@ -18,7 +18,7 @@ const SelectedInterests = ({ initialInterests, onSubmitInterests }) => {
                         <button className="submit-changes-btn" onClick={onSubmitInterests}>Submit changes</button>
                     </>
                     :
-                    <p>"You haven't selected any interests yet! Select some to get group recommendations."</p>
+                    <p>You haven't selected any interests yet! Select some to get group recommendations.</p>
                 }
                 
             </div>

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,8 @@ const authRoutes = require('./routes/auth')
 const interestRoutes = require('./routes/interests')
 const userSearchRoutes = require('./routes/userSearch')
 
+const EVENT_SEARCH_INTERVAL = 86400000; //1 day in milliseconds
+
 app.use(cors({
   origin: 'http://localhost:5173', 
   credentials: true
@@ -31,6 +33,36 @@ app.use(eventRoutes) //operations relating to user's event data
 app.use(groupRoutes) //operations relating to user's group data
 app.use(interestRoutes) //operations relating to getting and selecting interests
 app.use(userSearchRoutes) //endpoints for user search
+
+//this matches upcoming events to groups
+const triggerEventMatching = async () => {
+  try {
+    const response = await fetch('http://localhost:3000/events/search', {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+    });
+
+    const data = await response.json();
+
+    if (response.ok) {
+      return data;
+    } else {
+      throw { status: response.status, message: data.error };
+    }
+
+  } catch (error) {
+    console.log("Status ", error.status);
+    console.log("Error: ", error.message);
+  }
+
+}
+
+//run on startup
+triggerEventMatching();
+
+//set interval to run the function every time period specified by EVENT_SEARCH_INTERVAL 
+setInterval(triggerEventMatching, EVENT_SEARCH_INTERVAL);
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`)

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -27,6 +27,7 @@ const events = [
     {title: 'Tennis game', description: 'Tennis game in mpk', dateTime: new Date('2025-07-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 10}},
     {title: 'Indie Rock Concert', description: 'Indie Rock concert in mpk', dateTime: new Date('2025-12-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 7}},
     {title: 'ACDC concert', description: 'ACDC concert in mpk', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 9}},
+    {title: 'karaoke night', description: 'karaoke night out', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 4}},
     {title: 'Baking competition', description: 'Baking competition in mpk', dateTime: new Date('2025-10-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 11}},
     {title: 'Music festival', description: 'Music festival in Tokyo', dateTime: new Date('2025-09-25T12:00:00Z'), latitude: 35.6895, longitude: 139.6917, interest: {"id": 0}},
 

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -98,7 +98,7 @@ router.patch('/user/events/:eventId/status', isAuthenticated, async (req, res) =
 })
 
 //start event search for groups
-router.get('/events/search', isAuthenticated, async (req, res) => {
+router.get('/events/search', async (req, res) => {
    try {
        const allEvents = await scheduleEventsForGroups();
        res.status(200).json(allEvents);

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -195,11 +195,11 @@ router.put(`/user/groups/:groupId/${Status.ACCEPTED}`, isAuthenticated, async (r
             });
         }
 
+        //make sure new accepted member also receives existing event invites
         const eventIds = updatedGroupUser.group.events.map((eventGroup) => {
             return eventGroup.eventId;
         })
 
-        //make sure new accepted member also receives existing event invites
         await sendExistingEventsToUser(eventIds, req.session.userId);
 
 

--- a/server/systems/EventFindAlgo.js
+++ b/server/systems/EventFindAlgo.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { Status, filterGroupsByLocation } = require('./Utils');
+const { Status, filterGroupsByLocation, createEvent_User } = require('./Utils');
 
 
 const scheduleEventsForGroups = async () => {
@@ -25,7 +25,7 @@ const scheduleEventsForGroups = async () => {
                 await createGroup_Event(group.id, retrievedEvent.id);
                 //update user_event tables for each user in the group
                 for (member of group.members) {
-                    await createEvent_User(member.user, retrievedEvent.id);
+                    await createEvent_User(member.user.id, retrievedEvent.id);
                 }
 
             } else {
@@ -42,16 +42,6 @@ const createGroup_Event = async (groupId, eventId) => {
         data: {
             group: { connect: { id: groupId } },
             event: { connect: { id: eventId } }
-        }
-    })
-}
-
-const createEvent_User = async (user, eventId) => {
-    return await prisma.event_User.create({ 
-        data: {
-            user: { connect: { id: user.id } },
-            event: { connect: { id: eventId } },
-            status: Status.PENDING 
         }
     })
 }

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require('../generated/prisma');
 const prisma = new PrismaClient()
 
-const { getUnionOfSets } = require('./Utils');
+const { getUnionOfSets, createEvent_User } = require('./Utils');
 
 const updateGroupCentralLocation = (groupCoord, userCoord) => {
    //Given the fact that the accepted group's location and user's location are close by, the midpoint formula is good enough for midpoint calculation:
@@ -51,5 +51,20 @@ const recalculateGroupInterests = async (members, groupInterests) => {
     return newGroupInterests;
 }
 
+const sendExistingEventsToUser = async (eventIds, userId) => {
+    for (eventId of eventIds) {
+        await createEvent_User(userId, eventId)
+    }
+}
 
-module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation, recalculateGroupInterests };
+const removeEventInvitesFromUser = async () => {
+    //pass events from group
+    /**
+     * Event_user needs additional field that states groups this invite is due to
+     * Event_user fields are still unique, but when you delete a relation, only delete from the group id set and if it's empty then delete the event_user relation. 
+     */
+
+}
+
+
+module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation, recalculateGroupInterests, sendExistingEventsToUser };

--- a/server/systems/GroupUpdateMethods.js
+++ b/server/systems/GroupUpdateMethods.js
@@ -57,14 +57,4 @@ const sendExistingEventsToUser = async (eventIds, userId) => {
     }
 }
 
-const removeEventInvitesFromUser = async () => {
-    //pass events from group
-    /**
-     * Event_user needs additional field that states groups this invite is due to
-     * Event_user fields are still unique, but when you delete a relation, only delete from the group id set and if it's empty then delete the event_user relation. 
-     */
-
-}
-
-
 module.exports = { updateGroupCentralLocation, updateGroupInterests, recalculateGroupCentralLocation, recalculateGroupInterests, sendExistingEventsToUser };

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -109,6 +109,15 @@ const getOtherGroupMembers = async (userId) => {
     return groupMates;
 }
 
+const createEvent_User = async (userId, eventId) => {
+    return await prisma.event_User.create({ 
+        data: {
+            user: { connect: { id: userId } },
+            event: { connect: { id: eventId } },
+            status: Status.PENDING 
+        }
+    })
+}
 
 
-module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers };
+module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User };


### PR DESCRIPTION
## Description

**Done in this PR**
-Before, when event invites were sent out they were sent to only the users that were part of the group at that given time. If a user joined the group shortly after they would not see the event. This has now been fixed and users who join the group after are also invited.
-The event to group matching algorithm is now set up to be triggered on server start and every day. 

**Technical complexities and considerations**
-After discussion with Mandy, decided to try setInterval for my project's use case in event triggering. This can be inaccurate slightly, but complete accuracy isn't a concern for this use case. If this ends up being more unreliable or you may see a significant issue with this, please let me know if using a library would be better.

**Done in upcoming PRs**
-Loading state requirement 
-Profile page

## Milestones
-Users can join groups and get caught up on the upcoming events for that group

## Resources
https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval
https://stackoverflow.com/questions/24553863/how-do-i-call-a-function-at-start-in-expressjs-nodejs-setup-method

## Test Plan
-Tested by having a user join a group that already has events matched and the events now end up showing on their page too.
-Tested by having a user in MPK join and select the interest 'Karaoke' which has no related groups in the area. This creates a new group and there is an existing karaoke event in mpk in the DB that should be matched with it. On the next event matching trigger, this event showed up on the events page.
