### PR TITLE
Compatibility ratios for pending groups now adjust accordingly when user updates their interests. - BE Changes

### DIFF
--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -72,6 +72,34 @@ const getUnionOfSets = (groupInterests, userInterests) => {
     return groupInterestsSet.union(new Set(interestIds));
 }
 
+const adjustCandidateGroups = (groupCandidates, interestIds) => {
+    //for each group, need total for all interests and their weightings - used later in jaccard similarity calculation (will filter interests below so need to get this info now)
+    for (let i = 0; i < groupCandidates.length; i++) {
+        let allInterestsWeighted = 0;
+        for(let j = 0; j < groupCandidates[i].interests.length; j++) {
+            allInterestsWeighted += groupCandidates[i].interests[j].interest.level;
+        }
+        groupCandidates[i] = {...groupCandidates[i], totalWeight: allInterestsWeighted} //add as attribute to group object
+    }
+    
+    //additionally filter group interest list only by user's interests
+    for (group of groupCandidates) {
+        group.interests = group.interests.filter((interest) => {
+            return interestIds.includes(interest.interest.id);
+        });
+    }
+}
+
+const calcJaccardSimilarity = (group, numUserInterests) => {
+    let numerator = 0; //cardinality of intersection between group interest set and user interest set
+    for (groupInterest of group.interests) {
+        numerator += groupInterest.interest.level; //add up matching interests and their weightings
+    }
+    const denominator = (numUserInterests + group.totalWeight) - numerator; //cardinality of union between group interest set and user interest set
+
+    return numerator/denominator;
+}
+
 const filterMembersByStatus = (members, status) => {
     return members.filter((member) => {
         return member.status === status;
@@ -120,4 +148,4 @@ const createEvent_User = async (userId, eventId) => {
 }
 
 
-module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User };
+module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User, adjustCandidateGroups, calcJaccardSimilarity };


### PR DESCRIPTION
## Description

**Done in this PR**
-Handled an edge case from TC 1, where when a user updates their interests, the compatibility ratios of their pending groups do not adjust accordingly. Now, they do! On interest update, the user's compatibility ratios for their pending groups are recalculated. Additionally, if a recalculated compatibility ratio is found to be 0, that group_user relation is removed and it is no longer a suggested group for the user.

**Done in upcoming PRs**
-continue to handle some edge cases from tc1 
-create profile page
-handle some small UI bugs

## Milestones
-User can adjust their interests and get group recommendations according to this.

## Resources
None used here!

## Test Plan
As you can see, tennis is one of the group's interests, so when the user removes tennis as an interest, the compatibility ratio is recalculated.
https://www.loom.com/share/5855c24a7fe7415d9199c35f36712b23
