### PR TITLE
TC 1 Additional complexity - User event accept/reject/drop tracked which impacts group data - BE Changes

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Group {
   title           String
   description     String
   isFull          Boolean       @default(false)
-  eventTypeTotals Int[]
+  eventTypeTotals Decimal[]
   events          Group_Event[]
   members         Group_User[]
   interests       Group_Interest[]
@@ -79,8 +79,8 @@ model Event_User {
 model Group_User {
   userId              Int
   groupId             Int
-  status              Status @default(PENDING)
-  compatibilityRatio  Decimal @default("0.00")
+  status              Status     @default(PENDING)
+  compatibilityRatio  Decimal    @default("0.00")
   group               Group      @relation(fields: [groupId], references: [id])
   user                User       @relation(fields: [userId], references: [id])
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -9,15 +9,16 @@ datasource db {
 }
 
 model User {
-  id           Int           @id @default(autoincrement())
-  username     String        @unique
-  email        String        @unique
-  password     String
-  address      String
-  events       Event_User[]
-  groups       Group_User[]
-  userProfile  User_Profile?
-  interests    Interest[]
+  id               Int           @id @default(autoincrement())
+  username         String        @unique
+  email            String        @unique
+  password         String
+  address          String
+  eventTypeTallies Int[]
+  events           Event_User[]
+  groups           Group_User[]
+  userProfile      User_Profile?
+  interests        Interest[]
 }
 
 model User_Profile {
@@ -33,6 +34,7 @@ model Event {
   title       String
   description String
   dateTime    DateTime
+  eventType   Int
   interestId  Int?
   interest    Interest?     @relation(fields: [interestId], references: [id])
   attendees   Event_User[]
@@ -40,13 +42,14 @@ model Event {
 }
 
 model Group {
-  id          Int           @id @default(autoincrement())
-  title       String
-  description String
-  isFull      Boolean       @default(false)
-  events      Group_Event[]
-  members     Group_User[]
-  interests   Group_Interest[]
+  id              Int           @id @default(autoincrement())
+  title           String
+  description     String
+  isFull          Boolean       @default(false)
+  eventTypeTotals Int[]
+  events          Group_Event[]
+  members         Group_User[]
+  interests       Group_Interest[]
 }
 
 model Interest {

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -62,6 +62,7 @@ async function main() {
                         return { interest: { connect: interest } }
                     })
                 },
+                eventTypeTotals: new Array(EventType.NUMTYPES).fill(0)
             },
         })
 

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -1,4 +1,5 @@
 const { PrismaClient } = require('../generated/prisma');
+const { EventType } = require('../systems/Utils');
 const prisma = new PrismaClient()
 
 const interests = [
@@ -23,13 +24,13 @@ const groups = [
 ];
 
 const events = [
-    {title: 'Passed event', description: 'Passed event', dateTime: new Date('2025-05-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 10}},
-    {title: 'Tennis game', description: 'Tennis game in mpk', dateTime: new Date('2025-07-22T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 10}},
-    {title: 'Indie Rock Concert', description: 'Indie Rock concert in mpk', dateTime: new Date('2025-12-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 7}},
-    {title: 'ACDC concert', description: 'ACDC concert in mpk', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 9}},
-    {title: 'karaoke night', description: 'karaoke night out', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 4}},
-    {title: 'Baking competition', description: 'Baking competition in mpk', dateTime: new Date('2025-10-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 11}},
-    {title: 'Music festival', description: 'Music festival in Tokyo', dateTime: new Date('2025-09-25T12:00:00Z'), latitude: 35.6895, longitude: 139.6917, interest: {"id": 0}},
+    {title: 'Passed event', description: 'Passed event', dateTime: new Date('2025-05-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 10}, eventType: EventType.EATING},
+    {title: 'Tennis game', description: 'Tennis game in mpk', dateTime: new Date('2025-07-22T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 10}, eventType: EventType.ACTIVE},
+    {title: 'Indie Rock Concert', description: 'Indie Rock concert in mpk', dateTime: new Date('2025-12-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 7}, eventType: EventType.ENTERTAINMENT},
+    {title: 'ACDC concert', description: 'ACDC concert in mpk', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 9}, eventType: EventType.ENTERTAINMENT},
+    {title: 'karaoke night', description: 'karaoke night out', dateTime: new Date('2025-11-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 4}, eventType: EventType.ENTERTAINMENT},
+    {title: 'Baking competition', description: 'Baking competition in mpk', dateTime: new Date('2025-10-25T12:00:00Z'), latitude: 37.4855, longitude: -122.1500, interest: {"id": 11}, eventType: EventType.ACTIVE},
+    {title: 'Music festival', description: 'Music festival in Tokyo', dateTime: new Date('2025-09-25T12:00:00Z'), latitude: 35.6895, longitude: 139.6917, interest: {"id": 0}, eventType: EventType.ENTERTAINMENT},
 
 ]
 async function main() {
@@ -68,7 +69,7 @@ async function main() {
     }
 
      for (const event of events) {
-        const eventRecordId = await prisma.$queryRaw`INSERT INTO "Event" ("title", "description", "dateTime", "coord") VALUES(${event.title}, ${event.description}, ${event.dateTime}, ST_SetSRID(ST_MakePoint(${event.longitude}, ${event.latitude}), 4326)::geography) RETURNING id`;
+        const eventRecordId = await prisma.$queryRaw`INSERT INTO "Event" ("title", "description", "dateTime", "eventType", "coord") VALUES(${event.title}, ${event.description}, ${event.dateTime}, ${event.eventType}, ST_SetSRID(ST_MakePoint(${event.longitude}, ${event.latitude}), 4326)::geography) RETURNING id`;
 
         //for seeding, include interests - would not be done this way in finished product:
         await prisma.event.update({

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,6 +8,8 @@ const rateLimit = require("express-rate-limit");
 
 const opencage = require('opencage-api-client'); //public api
 
+const { EventType } = require('../systems/Utils');
+
 const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5, // Limit each IP to 5 login attempts per windowMs
@@ -76,7 +78,7 @@ router.post('/signup', async (req, res) => {
 
         // Create a new user in the database
         //for mock data, have all users start out with location at meta's headquarters
-        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ST_SetSRID(ST_MakePoint(${userCoords.longitude}, ${userCoords.latitude}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
+        const queryResult = await prisma.$queryRaw`INSERT INTO "User" (address, username, email, password, "eventTypeTallies", coord) VALUES(${address}, ${username}, ${email}, ${hashedPassword}, ${new Array(EventType.NUMTYPES).fill(0)}, ST_SetSRID(ST_MakePoint(${userCoords.longitude}, ${userCoords.latitude}), 4326)::geography) RETURNING id, address, username, email, password, ST_AsText(coord);`;
 
         const newUser = queryResult.at(0);
         // Store user ID and username in the session, allowing them to remain authenticated as they navigate the website

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -61,6 +61,7 @@ router.get('/user/groups/new', isAuthenticated, async (req, res) => {
                             return { interest: { connect: interest } }
                         })
                     },
+                    eventTypeTotals: new Array(EventType.NUMTYPES).fill(0)
                 },
                 include: {
                     interests: { include: { interest: true } }, members: { where: { NOT: { userId: req.session.userId } }, include: { user: true } }

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -181,6 +181,36 @@ const createEvent_User = async (userId, eventId) => {
 
 }
 
+const adjustGroupEventTypeTotals = (user, group, isDrop) => {
+
+    //order user's event type preferences based on tallies:
+
+    const sortableArr = user.eventTypeTallies.map((eventTypeTally, index) => {
+        return { tally: eventTypeTally, eventType: index }
+    })
+
+    sortableArr.sort((a, b) => b.tally - a.tally);
+
+    let newGroupEventTypeTotals = []
+
+    //get copy of group's eventTypeTotals array
+    if (group.eventTypeTotals.length === 0) {
+        newGroupEventTypeTotals = new Array(EventType.NUMTYPES).fill(0);
+    } else {
+        newGroupEventTypeTotals = [...group.eventTypeTotals]
+    }
+
+    //Need to combine user's event type array orderings (sortableArr version) with existing group array. 
+    let currLevel = EventType.NUMTYPES; //addition will occur based on how high an event type is ranked for current user. Highest = number of event types and lowest = 1
+    //start with user's highest ranked event type and add/subtract the corresponding ranking to the event type index in group array
+    for (let i = 0; i < sortableArr.length; i++) {
+        newGroupEventTypeTotals[sortableArr[i].eventType] = newGroupEventTypeTotals[sortableArr[i].eventType] + (isDrop ? -(currLevel) : currLevel); 
+        currLevel--;
+    }
+
+    return newGroupEventTypeTotals;
+}
+
 const adjustPendingUserCompatibilities = async (groupId, updatedGroup) => {
     //Now that group data has been updated, need to update the compatibility ratios for all the pending users for that group:
     const pendingUsersFetched = await prisma.group_User.findMany({
@@ -243,4 +273,4 @@ const adjustPendingUserCompatibilities = async (groupId, updatedGroup) => {
 }
 
 
-module.exports = { Status, EventType, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User, adjustCandidateGroups, calcJaccardSimilarity, adjustPendingUserCompatibilities};
+module.exports = { Status, EventType, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User, adjustCandidateGroups, calcJaccardSimilarity, adjustPendingUserCompatibilities, adjustGroupEventTypeTotals };

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -181,11 +181,19 @@ const createEvent_User = async (userId, eventId) => {
 
 }
 
+//borda count implementation
 const adjustGroupEventTypeTotals = (user, group, isDrop) => {
-
     //order user's event type preferences based on tallies:
 
+    let talliesMap = new Map()//key is tally number and values are count of number of event type (indices) in user eventTypeTallies with that tally. - this is necessary for duplicate handling later in this function
+
     const sortableArr = user.eventTypeTallies.map((eventTypeTally, index) => {
+        if (talliesMap.has(eventTypeTally)) {
+            talliesMap.set(eventTypeTally, talliesMap.get(eventTypeTally) + 1)
+        } else {
+            talliesMap.set(eventTypeTally, 1)
+        }
+       
         return { tally: eventTypeTally, eventType: index }
     })
 
@@ -203,7 +211,27 @@ const adjustGroupEventTypeTotals = (user, group, isDrop) => {
     //Need to combine user's event type array orderings (sortableArr version) with existing group array. 
     let currLevel = EventType.NUMTYPES; //addition will occur based on how high an event type is ranked for current user. Highest = number of event types and lowest = 1
     //start with user's highest ranked event type and add/subtract the corresponding ranking to the event type index in group array
+
+    //NOTE: the below for loop and the ones within it cannot be any larger than the number of event types, so there isn't a complexity concern here
     for (let i = 0; i < sortableArr.length; i++) {
+        if (talliesMap.get(sortableArr[i].tally) > 1) { 
+            //duplicate encountered, the next following talliesMap.get(sortableArr[i].tally) number of items should be the same duplicates
+            let newCurrLevel = currLevel;
+
+            //for duplicates, add all the currLevel values they would be if they weren't duplicates and divide by how many duplicates there are
+            const numDuplicates = talliesMap.get(sortableArr[i].tally);
+            for (let j = 1; j < numDuplicates; j++) {
+                newCurrLevel += (currLevel - j)
+            }
+            newCurrLevel /= numDuplicates;
+
+            for(let j = 0; j < numDuplicates; j++) {
+                newGroupEventTypeTotals[sortableArr[i + j].eventType] = newGroupEventTypeTotals[sortableArr[i + j].eventType] + (isDrop ? -(newCurrLevel) : newCurrLevel); 
+            }
+            i += (numDuplicates - 1);
+            currLevel -= numDuplicates;
+            continue;
+        }
         newGroupEventTypeTotals[sortableArr[i].eventType] = newGroupEventTypeTotals[sortableArr[i].eventType] + (isDrop ? -(currLevel) : currLevel); 
         currLevel--;
     }

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -12,6 +12,16 @@ const Status = Object.freeze({
     DROPPED: "DROPPED"
 });
 
+//enums for event type
+const EventType = Object.freeze({
+    JUSTMEET: 0,
+    ENTERTAINMENT: 1,
+    EATING: 2,
+    ACTIVE: 3
+});
+
+
+
 const getUserCoordinates = async (userId) => {
     const userCoord = await prisma.$queryRaw`
     SELECT ST_X(coord::geometry), ST_Y(coord::geometry)
@@ -232,4 +242,4 @@ const adjustPendingUserCompatibilities = async (groupId, updatedGroup) => {
 }
 
 
-module.exports = { Status, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User, adjustCandidateGroups, calcJaccardSimilarity, adjustPendingUserCompatibilities};
+module.exports = { Status, EventType, getUserCoordinates, getExpandedInterests, getUnionOfSets, filterMembersByStatus, filterGroupsByLocation, getOtherGroupMembers, createEvent_User, adjustCandidateGroups, calcJaccardSimilarity, adjustPendingUserCompatibilities};

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -17,7 +17,8 @@ const EventType = Object.freeze({
     JUSTMEET: 0,
     ENTERTAINMENT: 1,
     EATING: 2,
-    ACTIVE: 3
+    ACTIVE: 3,
+    NUMTYPES: 4 //specifies number of different event types
 });
 
 

--- a/server/systems/Utils.js
+++ b/server/systems/Utils.js
@@ -205,7 +205,9 @@ const adjustGroupEventTypeTotals = (user, group, isDrop) => {
     if (group.eventTypeTotals.length === 0) {
         newGroupEventTypeTotals = new Array(EventType.NUMTYPES).fill(0);
     } else {
-        newGroupEventTypeTotals = [...group.eventTypeTotals]
+        for (eventTypeTotal of group.eventTypeTotals) {
+            newGroupEventTypeTotals.push(Number(eventTypeTotal)); //prisma formats Decimals as string, need to convert to number
+        }
     }
 
     //Need to combine user's event type array orderings (sortableArr version) with existing group array. 


### PR DESCRIPTION
## Description

**Done in this PR**
-To add to complexity for my first technical challenge, I created a new factor that users can use to decide which groups they may want to join: members' ranked event types. Now, events are categorized into the following categories: "Just meet", "Entertainment", "Eating", and "Active". User behavior of accepting, rejecting, and dropping events is tracked so that a group can be defined by its collective members' most to least liked types of events. This information will be visible to the user to give additional insight into the group's dynamic when deciding on joining the group. 

-Additionally, once a user accepts a group, their event behavior after is still tracked and updated in the groups they accepted. This is necessary to maintain accurate and up-to-date information.

**Technical complexities and considerations**
-This merging of user preferences in event types was done with the Borda count voting technique (check resources below). After research, I found this voting theory to be the most adaptable to my use case in terms of necessary information and efficiency. For example, I found that updates in event choice, accepting, and dropping groups would be frequent and need to be able to update the group's event type array efficiently. With other techniques than Borda, updates would require all preferences of all members in a group to have to be combined just for one new member. However, with Borda count, the group's existing event type array can be used for a quicker operation. This applies to event behavior changes as well.

-There is a need for sorting these event type arrays for groups and users on each operation, but I didn't consider this a time complexity issue as the array sizes are restricted by the amount of event types (currently 4) and event type is a fairly limited category. I could have changed the way event type preferences and tallies were stored for users and groups to avoid this (such as two arrays to store tallies and preference order separately) , but these options were a larger space complexity concern.

**Done in upcoming PRs**
-Integrate this code with my frontend

## Milestones
-Users get details on a group's overall dynamic for support in user's group choices.

## Resources
https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
https://medium.com/basic-voting-theory/the-borda-count-9d4f15b4d20e

The technique under "Average" here is an example very similar to the idea of Borda Count:
https://www.ideaclouds.net/new-ranking-techniques/

Note: the below resource helped me learn how borda count handles duplicate rankings:
https://nhulkower.medium.com/moving-beyond-majority-rule-and-ranked-choice-voting-cdd41497d634

## Test Plan
-Tested many scenarios making sure that when users interact with events, the necessary changes are reflected in the groups they're in (borda count operation). This should also apply with group accepts and drops. 

-Writing out the math for these results helped me recognize edge cases and desired outcome easier!
