### PR TITLE
TC1 - Event type preferences for group displayed in group modal. Events are suggested based on user event type data as well - FE Changes

### DIFF
--- a/client/src/components/Card.jsx
+++ b/client/src/components/Card.jsx
@@ -6,7 +6,7 @@ import InteractiveStatusIcon from './InteractiveStatusIcon';
 import "../styles/Card.css"
 
 //general Card component used by Group.jsx and Event.jsx
-const Card = ({fields, cardData, compatibilityRatio, status, onUpdate, modalFields, isGroup}) => {
+const Card = ({fields, cardData, compatibilityRatio, status, onUpdate, modalFields, isGroup, isTopEventType}) => {
 
     const [isModalVisible, setIsModalVisible] = useState(false);
 
@@ -19,6 +19,7 @@ const Card = ({fields, cardData, compatibilityRatio, status, onUpdate, modalFiel
 
     return (<>
         <div className="card" onClick={openModal}>
+            {(!isGroup && status !== Status.ACCEPTED && isTopEventType) && <p>We think you'll like this event!</p>}
             <section className="card-header">
                 {fields.has(CardFields.STATUS) && <InteractiveStatusIcon isGroup={isGroup} isWithinModal={false} status={status}/>}
                 {fields.has(CardFields.TITLE) && <h4 className="title">{cardData.title}</h4>}

--- a/client/src/components/Event.jsx
+++ b/client/src/components/Event.jsx
@@ -3,7 +3,8 @@ import { CardFields, ModalFields } from "../utils/utils"
 import APIUtils from '../utils/APIUtils';
 import "../styles/Card.css";
 
-const Event = ( {eventData, onUpdateEvent}) => {
+const Event = ( {eventData, onUpdateEvent, isTopEventType}) => {
+
     const { id } = eventData.event;
 
     const updateEvent = async(statusState) => {
@@ -22,6 +23,7 @@ const Event = ( {eventData, onUpdateEvent}) => {
             cardData={eventData.event} 
             status={eventData.status} 
             isGroup={false}
+            isTopEventType={isTopEventType}
             fields={new Set([CardFields.TITLE, CardFields.DESCRIPTION, CardFields.DATEANDTIME, CardFields.STATUS])}
             modalFields={new Set([ModalFields.TITLE, ModalFields.DESCRIPTION, ModalFields.INTEREST, ModalFields.ATTENDEES])}  
             onUpdate={updateEvent}

--- a/client/src/components/EventTypePreferenceDisplay.jsx
+++ b/client/src/components/EventTypePreferenceDisplay.jsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react';
+import { EventTypeArr } from "../utils/utils";
+import "../styles/EventTypePreferenceDisplay.css";
+
+const EventTypePreferenceDisplay = ({ eventTypeTotals }) => {
+
+    const colors = ['red', 'green', 'blue', '#9929EA']; // TODO: should make dynamic
+
+    let cumulativeTotals = 0;
+    for (let i = 0; i < eventTypeTotals.length; i++) {
+        cumulativeTotals += Number(eventTypeTotals[i])
+    }
+
+    const eventTypeAngles = eventTypeTotals.map((eventTypeTotal) => {
+        if (cumulativeTotals == 0) return 90;
+        return (eventTypeTotal/cumulativeTotals) * 360;
+    })
+
+    let passedStyling = colors[0] + " " + 0 + 'deg,' + colors[0] + " " + eventTypeAngles[0].toString() + 'deg,';
+    
+    let prevAngle = eventTypeAngles[0];
+    for (let i = 1; i < eventTypeAngles.length; i++) {
+        passedStyling += colors[i] + " " + prevAngle.toString() + 'deg,';
+        passedStyling += colors[i] + " " + (prevAngle + eventTypeAngles[i]).toString() + 'deg,';
+        prevAngle  = prevAngle + eventTypeAngles[i];
+    }
+    passedStyling = passedStyling.substring(0, passedStyling.length - 1);
+
+
+    return (
+        <div className="event-type-display">
+            <div className="event-type-pie-chart" style={{'--calculated-conic-gradient': passedStyling}}></div>
+            <div className="event-type-legend">
+                <Suspense fallback={<p>Loading legend...</p>}>
+                    {eventTypeTotals.map((eventTypeTotal, index) => (
+                        <p className="event-type-key" key={eventTypeTotal + index} style={{'--text-color': colors[index]}}>{EventTypeArr.at(index)}</p>
+                    ))}
+                </Suspense>
+            </div>
+        </div>
+    )
+}
+
+export default EventTypePreferenceDisplay;

--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -28,7 +28,7 @@ const Group = ( {groupData, onUpdateGroup}) => {
         status={groupData.status} 
         isGroup={true}
         fields={new Set([CardFields.TITLE, CardFields.DESCRIPTION, CardFields.COMPATIBILITY, CardFields.STATUS])} 
-        modalFields={new Set([ModalFields.TITLE, ModalFields.DESCRIPTION, ModalFields.INTERESTS, ModalFields.PEOPLE])} 
+        modalFields={new Set([ModalFields.TITLE, ModalFields.DESCRIPTION, ModalFields.INTERESTS, ModalFields.PEOPLE, ModalFields.EVENT_PREFERENCES])} 
         onUpdate={updateGroup}
     />
 }

--- a/client/src/components/Group.jsx
+++ b/client/src/components/Group.jsx
@@ -3,7 +3,6 @@ import { CardFields, ModalFields, Status } from "../utils/utils";
 import APIUtils from '../utils/APIUtils';
 import "../styles/Card.css";
 
-
 const Group = ( {groupData, onUpdateGroup}) => {
     const { id } = groupData.group;
 

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,5 +1,5 @@
-import { Suspense } from 'react';
-import { ModalFields, Status } from "../utils/utils";
+import { useMemo, Suspense } from 'react';
+import { ModalFields, Status, EventTypeArr } from "../utils/utils";
 import StatusForm from './StatusForm';
 import SingularSelectedInterest from './SingularSelectedInterest';
 import MemberTile from './MemberTile';
@@ -7,6 +7,17 @@ import "../styles/Modal.css";
 
 //general Modal component used by Group.jsx and Event.jsx
 const Modal = ({ onModalClose, cardData, onStatusUpdate, fields, status, isGroup }) => {
+
+    const sortedEventTypeTotals = useMemo(
+        () => {
+            const sortableArr = cardData.eventTypeTotals.map((eventTypeTotal, index) => {
+                return { total: eventTypeTotal, eventType: index }
+            })
+            sortableArr.sort((a, b) => b.total - a.total);
+            return sortableArr;
+        },
+        []
+    );
 
     return (
     <div className="overlay">
@@ -25,6 +36,19 @@ const Modal = ({ onModalClose, cardData, onStatusUpdate, fields, status, isGroup
                             <Suspense fallback={<p>Loading Interests...</p>}>
                                 {cardData.interests.map((interest) => (
                                     <SingularSelectedInterest key={interest.interest.id} interest={interest.interest.title} />
+                                ))}
+                            </Suspense>
+                        </section>
+                    </>
+                }
+
+                {fields.has(ModalFields.EVENT_PREFERENCES) &&
+                    <>
+                        <h2>Member event preferences:</h2>
+                        <section className='interests'>
+                            <Suspense fallback={<p>Loading event type preferences...</p>}>
+                                {sortedEventTypeTotals.map((eventTypeObj) => (
+                                    <p key={eventTypeObj.index + eventTypeObj.total}>{EventTypeArr.at(eventTypeObj.eventType)}</p>
                                 ))}
                             </Suspense>
                         </section>

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,23 +1,13 @@
-import { useMemo, Suspense } from 'react';
-import { ModalFields, Status, EventTypeArr } from "../utils/utils";
+import { Suspense } from 'react';
+import { ModalFields, Status } from "../utils/utils";
 import StatusForm from './StatusForm';
 import SingularSelectedInterest from './SingularSelectedInterest';
 import MemberTile from './MemberTile';
+import EventTypePreferenceDisplay from './EventTypePreferenceDisplay';
 import "../styles/Modal.css";
 
 //general Modal component used by Group.jsx and Event.jsx
 const Modal = ({ onModalClose, cardData, onStatusUpdate, fields, status, isGroup }) => {
-
-    const sortedEventTypeTotals = useMemo(
-        () => {
-            const sortableArr = cardData.eventTypeTotals.map((eventTypeTotal, index) => {
-                return { total: eventTypeTotal, eventType: index }
-            })
-            sortableArr.sort((a, b) => b.total - a.total);
-            return sortableArr;
-        },
-        []
-    );
 
     return (
     <div className="overlay">
@@ -45,13 +35,7 @@ const Modal = ({ onModalClose, cardData, onStatusUpdate, fields, status, isGroup
                 {fields.has(ModalFields.EVENT_PREFERENCES) &&
                     <>
                         <h2>Member event preferences:</h2>
-                        <section className='interests'>
-                            <Suspense fallback={<p>Loading event type preferences...</p>}>
-                                {sortedEventTypeTotals.map((eventTypeObj) => (
-                                    <p key={eventTypeObj.index + eventTypeObj.total}>{EventTypeArr.at(eventTypeObj.eventType)}</p>
-                                ))}
-                            </Suspense>
-                        </section>
+                        <EventTypePreferenceDisplay eventTypeTotals={cardData.eventTypeTotals}/>
                     </>
                 }
 

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -34,7 +34,7 @@ const Modal = ({ onModalClose, cardData, onStatusUpdate, fields, status, isGroup
 
                 {fields.has(ModalFields.EVENT_PREFERENCES) &&
                     <>
-                        <h2>Member event preferences:</h2>
+                        <h2>Member Event Type Preferences:</h2>
                         <EventTypePreferenceDisplay eventTypeTotals={cardData.eventTypeTotals}/>
                     </>
                 }

--- a/client/src/pages/EventsList.jsx
+++ b/client/src/pages/EventsList.jsx
@@ -6,9 +6,7 @@ import FilterOptions from "../components/FilterOptions";
 import APIUtils from '../utils/APIUtils';
 import "../styles/CardListContainer.css"
 
-const EventsList = () => {
-
-
+const EventsList = ({ userTopEventType }) => {
     const [events, setEvents] = useState(new Map());
     const [statusFilter, setStatusFilter] = useState(Status.NONE);
     const displayedEvents = useMemo(
@@ -49,6 +47,7 @@ const EventsList = () => {
                     <Event 
                         key={key}
                         eventData={value}
+                        isTopEventType={(value.event.eventType == userTopEventType)}
                         onUpdateEvent= {(newEventObj) => {
                             const updatedEvents = new Map(events);
                             updatedEvents.set(newEventObj.eventId, newEventObj);

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -8,7 +8,6 @@ import "../styles/CardListContainer.css"
 
 const GroupsList = () => {
 
-
     const [groups, setGroups] = useState(new Map());
     const [statusFilter, setStatusFilter] = useState(Status.NONE);
     const displayedGroups = useMemo(

--- a/client/src/pages/GroupsList.jsx
+++ b/client/src/pages/GroupsList.jsx
@@ -7,7 +7,6 @@ import APIUtils from '../utils/APIUtils';
 import "../styles/CardListContainer.css"
 
 const GroupsList = () => {
-
     const [groups, setGroups] = useState(new Map());
     const [statusFilter, setStatusFilter] = useState(Status.NONE);
     const displayedGroups = useMemo(

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -1,19 +1,51 @@
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";
 import EventsList from './EventsList';
 import GroupsList from './GroupsList';
 import InterestList from './InterestList';
+import APIUtils from '../utils/APIUtils';
 import { Tab } from "../utils/utils";
 
 const MainPage = () => {
 
+    const [userEventTypeTallies, setUserEventTypeTallies] = useState([]);
     const [selectedTab, setSelectedTab] = useState(Tab.EVENTS);
+
+    const userTopEventType = useMemo(
+        () => { 
+            let currFavEventType = -1;
+            let currMax = 0
+            for (let i = 0; i < userEventTypeTallies.length; i++) {
+                if (userEventTypeTallies[i] > currMax) {
+                    currFavEventType = i;
+                    currMax = userEventTypeTallies[i]
+                }
+            }
+            return currFavEventType;
+        },
+        [userEventTypeTallies]
+    )
+
+    useEffect(() => {
+        fetchUserEventTypeTallies();
+    }, []);
+
+    const fetchUserEventTypeTallies = async () => {
+        try {
+            const apiResultData = await APIUtils.fetchUserEventTypeTallies();
+            (apiResultData)
+            setUserEventTypeTallies(apiResultData.eventTypeTallies);
+        } catch (error) {
+            console.log("Status ", error.status);
+            console.log("Error: ", error.message);
+        }
+    }
 
     const newDisplay = () => {
         switch(selectedTab) {
             case Tab.EVENTS: 
-                return <EventsList/>
+                return <EventsList userTopEventType={userTopEventType} />
             case Tab.GROUPS: 
                 return <GroupsList />
             case Tab.INTERESTS:

--- a/client/src/styles/EventTypePreferenceDisplay.css
+++ b/client/src/styles/EventTypePreferenceDisplay.css
@@ -1,0 +1,19 @@
+.event-type-display {
+    display: flex;
+    align-items: center;
+}
+
+.event-type-pie-chart {
+    width: 100px;
+    height: 100px;
+    background-color: transparent;
+    border-radius: 50%;
+    border: solid grey 1px;
+    background: conic-gradient(var(--calculated-conic-gradient));
+    margin: 0px 18px 0px 10px;
+} 
+
+.event-type-key {
+    color: var(--text-color);
+    font-size: 20px;
+}

--- a/client/src/utils/APIUtils.js
+++ b/client/src/utils/APIUtils.js
@@ -53,6 +53,22 @@ export default class APIUtils {
 
     }
 
+    static fetchUserEventTypeTallies = async () => {
+        const response = await fetch("http://localhost:3000/user/tallies", {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            return data;
+        } else {
+            throw {status: response.status, message: data.error};
+        }
+    }
+
     static fetchEvents = async () => {
         const response = await fetch("http://localhost:3000/user/events/", {
             method: "GET",

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -40,8 +40,12 @@ const ModalFields = Object.freeze({
     INTERESTS: "interests",
     PEOPLE: "people",
     ATTENDEES: "attendees",
-    INTEREST: "interest"
+    INTEREST: "interest",
+    EVENT_PREFERENCES: "eventTypePreferences"
 });
 
+//array used to map index to event type string
+const EventTypeArr = ["Just Meet", "Entertainment", "Eating", "Active"]
 
-export { Tab, Status, DEFAULT_FORM_VALUE, CardFields, ModalFields };
+
+export { Tab, Status, DEFAULT_FORM_VALUE, CardFields, ModalFields, EventTypeArr };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -58,6 +58,22 @@ router.get('/user/events/', isAuthenticated, async (req, res) => {
     }
 })
 
+//get user eventTypeTallies
+router.get('/user/tallies', isAuthenticated, async (req, res) => {
+    try {
+        const eventTypeTallies = await prisma.user.findUnique({
+            where: {
+                id: req.session.userId, 
+            },
+            select: {eventTypeTallies: true}
+        })
+        res.status(201).json(eventTypeTallies);
+    } catch (error) {
+        console.error("Error fetching user event type tallies:", error)
+        res.status(500).json({ error: "Something went wrong while fetching user event type tallies." })
+    }
+})
+
 //update user's status for an event
 router.patch('/user/events/:eventId/status', isAuthenticated, async (req, res) => {
     const eventId = parseInt(req.params.eventId);


### PR DESCRIPTION
## Description

**Done in this PR**
-TC 1 additional complexity highlighted from last PR is now integrated in the frontend. Now, when users view group modals, they can see a pie chart break down of the event types that are most popular within the group. 
-Additionally, when users who are part of a group interact with more events, this change is reflected in the group's pie chart.
-I also made it so that if there is pending event on the user's events page that aligns with the user's top event type, it has a header "We think you'll like this!"

**Done in upcoming PRs**
-Continue to build on UI

## Milestones
-User can gain insight into a group by seeing a breakdown of the event type preferences. Users can also get events suggested based on their previous behavior.


## Resources
https://www.w3schools.com/css/css3_gradients_conic.asp

## Test Plan
<img width="801" height="980" alt="Screenshot 2025-07-24 at 4 48 25 PM" src="https://github.com/user-attachments/assets/10d6fb7e-76a7-4d78-a31e-ab92337573af" />

<img width="1186" height="1002" alt="Screenshot 2025-07-24 at 4 49 19 PM" src="https://github.com/user-attachments/assets/9701e0f6-42f9-4b35-85d1-8462a9fba516" />

